### PR TITLE
Build nativeTest under GraalVM Native Image in parallel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,4 +62,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
       - run: |
-          ./mvnw -PnativeTestInCustom clean test
+          ./mvnw -T 1.5C -PnativeTestInCustom clean test

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -28,7 +28,7 @@ sdk use java 22.0.2-graalce
 git clone git@github.com:linghengqian/hive-server2-jdbc-driver.git
 cd ./hive-server2-jdbc-driver/
 sdk use java 22.0.2-graalce
-./mvnw -PnativeTestInCustom clean test
+./mvnw -T 1.5C -PnativeTestInCustom clean test
 ```
 
 ### Fixes LICENSE issue


### PR DESCRIPTION
- Fixes #3 .
- Build nativeTest under GraalVM Native Image in parallel.
- It looks like with the update of `org.graalvm.buildtools:native-maven-plugin` to 0.10.3, the Error Log no longer appears. For https://github.com/graalvm/native-build-tools/issues/619 .