### PR TITLE
Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## v1
 
+### 1.6.0-SNAPSHOT
+
+1. Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image.
+
+Build from `apache/hive:rel/release-4.0.1`.
+
+```
+io.github.linghengqian:hive-server2-jdbc-driver-thin:1.6.0-SNAPSHOT
+io.github.linghengqian:hive-server2-jdbc-driver-uber:1.6.0-SNAPSHOT
+```
+
 ### 1.5.0
 
 1. Bump base HiveServer2 JDBC Driver version to `4.0.1`.

--- a/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
+++ b/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
@@ -1,7 +1,676 @@
 [
 {
-  "condition":{"typeReachable":"com.github.dockerjava.api.model.RuntimeInfo"},
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Bind;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Capability;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Device;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.ExposedPort;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Link;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.LxcConf;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.PortBinding;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Ports$Binding;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Ulimit;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Volume;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumeBind;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumeRW;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Ljava.lang.String;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lorg.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.CreateContainerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.CreateContainerResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setWarnings","parameterTypes":["java.lang.String[]"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.DockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.GraphData",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.GraphDriver",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.HealthState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.HealthStateLog",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$ContainerState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "queryAllPublicConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":["com.github.dockerjava.api.command.InspectContainerResponse"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$Mount",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$Node",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectImageResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.RootFS",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.SyncDockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.AccessMode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.AuthConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Bind",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BindOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BindPropagation",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Binds",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.lang.String[]"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BlkioRateDevice",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BlkioWeightDevice",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Capability",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ClusterInfo",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerNetwork",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "allPublicMethods": true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerNetwork$Ipam",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Device",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.DeviceRequest",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.DockerObject",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"getRawValues","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Driver",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExposedPort",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExposedPorts",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.util.Map"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExternalCA",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExternalCAProtocol",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.HealthCheck",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.HostConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAutoRemove","parameterTypes":[] }, {"name":"getBlkioDeviceReadBps","parameterTypes":[] }, {"name":"getBlkioDeviceReadIOps","parameterTypes":[] }, {"name":"getBlkioDeviceWriteBps","parameterTypes":[] }, {"name":"getBlkioDeviceWriteIOps","parameterTypes":[] }, {"name":"getBlkioWeight","parameterTypes":[] }, {"name":"getBlkioWeightDevice","parameterTypes":[] }, {"name":"getCapAdd","parameterTypes":[] }, {"name":"getCapDrop","parameterTypes":[] }, {"name":"getCgroup","parameterTypes":[] }, {"name":"getCgroupParent","parameterTypes":[] }, {"name":"getCgroupnsMode","parameterTypes":[] }, {"name":"getConsoleSize","parameterTypes":[] }, {"name":"getContainerIDFile","parameterTypes":[] }, {"name":"getCpuCount","parameterTypes":[] }, {"name":"getCpuPercent","parameterTypes":[] }, {"name":"getCpuPeriod","parameterTypes":[] }, {"name":"getCpuQuota","parameterTypes":[] }, {"name":"getCpuRealtimePeriod","parameterTypes":[] }, {"name":"getCpuRealtimeRuntime","parameterTypes":[] }, {"name":"getCpuShares","parameterTypes":[] }, {"name":"getCpusetCpus","parameterTypes":[] }, {"name":"getCpusetMems","parameterTypes":[] }, {"name":"getDeviceCgroupRules","parameterTypes":[] }, {"name":"getDeviceRequests","parameterTypes":[] }, {"name":"getDevices","parameterTypes":[] }, {"name":"getDiskQuota","parameterTypes":[] }, {"name":"getDns","parameterTypes":[] }, {"name":"getDnsOptions","parameterTypes":[] }, {"name":"getDnsSearch","parameterTypes":[] }, {"name":"getExtraHosts","parameterTypes":[] }, {"name":"getGroupAdd","parameterTypes":[] }, {"name":"getInit","parameterTypes":[] }, {"name":"getIoMaximumBandwidth","parameterTypes":[] }, {"name":"getIoMaximumIOps","parameterTypes":[] }, {"name":"getIpcMode","parameterTypes":[] }, {"name":"getIsolation","parameterTypes":[] }, {"name":"getKernelMemory","parameterTypes":[] }, {"name":"getLxcConf","parameterTypes":[] }, {"name":"getMemory","parameterTypes":[] }, {"name":"getMemoryReservation","parameterTypes":[] }, {"name":"getMemorySwap","parameterTypes":[] }, {"name":"getMemorySwappiness","parameterTypes":[] }, {"name":"getMounts","parameterTypes":[] }, {"name":"getNanoCPUs","parameterTypes":[] }, {"name":"getNetworkMode","parameterTypes":[] }, {"name":"getOomKillDisable","parameterTypes":[] }, {"name":"getOomScoreAdj","parameterTypes":[] }, {"name":"getPidMode","parameterTypes":[] }, {"name":"getPidsLimit","parameterTypes":[] }, {"name":"getPortBindings","parameterTypes":[] }, {"name":"getPrivileged","parameterTypes":[] }, {"name":"getPublishAllPorts","parameterTypes":[] }, {"name":"getReadonlyRootfs","parameterTypes":[] }, {"name":"getRestartPolicy","parameterTypes":[] }, {"name":"getRuntime","parameterTypes":[] }, {"name":"getSecurityOpts","parameterTypes":[] }, {"name":"getShmSize","parameterTypes":[] }, {"name":"getStorageOpt","parameterTypes":[] }, {"name":"getSysctls","parameterTypes":[] }, {"name":"getTmpFs","parameterTypes":[] }, {"name":"getUlimits","parameterTypes":[] }, {"name":"getUsernsMode","parameterTypes":[] }, {"name":"getUtSMode","parameterTypes":[] }, {"name":"getVolumeDriver","parameterTypes":[] }, {"name":"getVolumesFrom","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Image",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Info",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InfoRegistryConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InfoRegistryConfig$IndexConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InternetProtocol",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Isolation",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Link",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Links",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LocalNodeState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"forValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LogConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setType","parameterTypes":["com.github.dockerjava.api.model.LogConfig$LoggingType"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LogConfig$LoggingType",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LxcConf",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Mount",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.MountType",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.NetworkSettings",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.PeerNode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ports",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.util.Map"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ports$Binding",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.PropagationMode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ResourceVersion",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.RestartPolicy",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
   "name":"com.github.dockerjava.api.model.RuntimeInfo",
-  "allPublicConstructors": true
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPath","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SELContext",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmCAConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmDispatcherConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmInfo",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmOrchestration",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmRaftConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmSpec",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.TaskDefaults",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.TmpfsOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ulimit",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Version",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VersionComponent",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VersionPlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Volume",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeBind",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeBinds",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeRW",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Volumes",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumesFrom",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumesRW",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.command.CreateNetworkCmd"},
+  "name":"com.github.dockerjava.api.command.CreateNetworkCmd",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.command.CreateNetworkResponse"},
+  "name":"com.github.dockerjava.api.command.CreateNetworkResponse",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.PullResponseItem",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$AuxDetail",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$ErrorDetail",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$ProgressDetail",
+  "allDeclaredMethods": true
 }
 ]

--- a/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/resource-config.json
+++ b/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.apache.calcite.avatica.remote.Driver"},
+    "pattern":"\\Qorg-apache-calcite-jdbc.properties\\E"
+  }]},
+  "bundles":[]
+}

--- a/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
+++ b/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.apache.zookeeper/zookeeper/3.9.0/reflect-config.json
@@ -1,0 +1,56 @@
+[
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.ZooKeeper"},
+  "name":"org.apache.zookeeper.ClientCnxnSocketNIO",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.zookeeper.client.ZKClientConfig"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.quorum.QuorumPeerConfig"},
+  "name":"org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.ConnectionMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.DataTreeMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.zookeeper.server.NIOServerCnxnFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.zookeeper.server.ZooKeeperServerMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.zookeeper.server.watch.WatchManagerFactory"},
+  "name":"org.apache.zookeeper.server.watch.WatchManager",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
+]

--- a/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
+++ b/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
@@ -1,0 +1,195 @@
+[
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ArrayBuilders"},
+  "name":"[Lorg.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.ClickHouseProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.MSSQLServerContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PgVectorContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PostgisContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PostgreSQLContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.TimescaleDBContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.DockerDesktopClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.DockerMachineClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.NpipeSocketClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.TestcontainersHostPropertyClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.UnixSocketClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+  "name":"org.testcontainers.dockerclient.UnixSocketClientProviderStrategy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7Support"},
+  "name":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuths","parameterTypes":["java.util.Map"] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrAsyncDockerCmd",
+  "queryAllDeclaredMethods":true,
+  "allDeclaredFields": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateNetworkCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd",
+  "queryAllDeclaredMethods":true,
+  "allDeclaredFields": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateNetworkCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateNetworkCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"getAttachable","parameterTypes":[] }, {"name":"getCheckDuplicate","parameterTypes":[] }, {"name":"getDriver","parameterTypes":[] }, {"name":"getEnableIPv6","parameterTypes":[] }, {"name":"getInternal","parameterTypes":[] }, {"name":"getIpam","parameterTypes":[] }, {"name":"getLabels","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getOptions","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"getContainerId","parameterTypes":[] }, {"name":"getEnv","parameterTypes":[] }, {"name":"getPrivileged","parameterTypes":[] }, {"name":"getUser","parameterTypes":[] }, {"name":"getWorkingDir","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.ExecStartCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer$$Lambda/0x00007f841f23d008"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.hamcrest.TypeSafeMatcher"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.hamcrest.internal.ReflectiveTypeFinder"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl",
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.junit.jupiter.Testcontainers"},
+  "name":"org.testcontainers.junit.jupiter.Testcontainers",
+  "allPublicMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl$NetworkingConfig",
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam$Config",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$ContainerNetworkConfig",
+  "allDeclaredMethods": true
+}
+]

--- a/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/resource-config.json
+++ b/hive-server2-jdbc-driver-thin/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/resource-config.json
@@ -1,0 +1,32 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.core.CreateContainerCmdModifier\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.shaded.com.google.common.io.Resources"},
+    "pattern":"\\Qcontainer-license-acceptance.txt\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.containers.wait.strategy.HostPortWaitStrategy"},
+    "pattern":"\\Qlogback-test.xml\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.utility.ClasspathScanner"},
+    "pattern":"\\Qtestcontainers.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.utility.ImageNameSubstitutor"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.utility.ImageNameSubstitutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig"},
+    "pattern":"\\Qdocker-java.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+    "pattern":"\\QMETA-INF/services/java.net.spi.InetAddressResolverProvider\\E"
+  }]},
+  "bundles":[]
+}

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HiveZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HiveZookeeperServiceDiscoveryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Qiheng He
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.linghengqian.hive.server2.jdbc.driver.thin;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.sql.*;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "resource", "deprecation"})
+@Testcontainers
+class HiveZookeeperServiceDiscoveryTest {
+
+    private static final int RANDOM_PORT_FIRST = getRandomPort();
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final GenericContainer<?> ZOOKEEPER_CONTAINER = new GenericContainer<>("zookeeper:3.9.3-jre-17")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("foo")
+            .withExposedPorts(2181);
+
+    @Container
+    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+            .withNetwork(NETWORK)
+            .withEnv("SERVICE_NAME", "hiveserver2")
+            .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                    + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                    + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                    + "-Dhive.server2.thrift.port=" + RANDOM_PORT_FIRST)
+            .withFixedExposedPort(RANDOM_PORT_FIRST, RANDOM_PORT_FIRST)
+            .dependsOn(ZOOKEEPER_CONTAINER);
+
+    private final String jdbcUrlSuffix = ";serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2";
+
+    private String jdbcUrlPrefix;
+
+    @AfterAll
+    static void afterAll() {
+        NETWORK.close();
+    }
+
+    @Test
+    void assertShardingInLocalTransactions() throws SQLException {
+        jdbcUrlPrefix = "jdbc:hive2://" + ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181) + "/";
+        DataSource dataSource = createDataSource();
+        extracted(dataSource);
+        HIVE_SERVER2_1_CONTAINER.stop();
+        int randomPortSecond = getRandomPort();
+        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+                .withNetwork(NETWORK)
+                .withEnv("SERVICE_NAME", "hiveserver2")
+                .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                        + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                        + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                        + "-Dhive.server2.thrift.port=" + randomPortSecond)
+                .withFixedExposedPort(randomPortSecond, randomPortSecond)
+                .dependsOn(ZOOKEEPER_CONTAINER)) {
+            hiveServer2SecondContainer.start();
+            extracted(hiveServer2SecondContainer.getMappedPort(randomPortSecond));
+            extracted(dataSource);
+        }
+    }
+
+    private static void extracted(DataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE demo_ds_0");
+            ResultSet firstResultSet = statement.executeQuery("show tables");
+            assertThat(firstResultSet.next(), is(false));
+            statement.execute("create table hive_example(a string, b int) partitioned by(c int)");
+            statement.execute("alter table hive_example add partition(c=1)");
+            statement.execute("insert into hive_example partition(c=1) values('a', 1), ('a', 2),('b',3)");
+            ResultSet secondResultSet = statement.executeQuery("select count(distinct a) from hive_example");
+            assertThat(secondResultSet.next(), is(true));
+            assertThat(secondResultSet.getInt("_c0"), is(2));
+            ResultSet thirdResultSet = statement.executeQuery("select sum(b) from hive_example");
+            assertThat(thirdResultSet.next(), is(true));
+            assertThat(thirdResultSet.getInt("_c0"), is(6));
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        return DriverManager.getConnection(jdbcUrlPrefix + jdbcUrlSuffix, props);
+    }
+
+    private DataSource createDataSource() {
+        extracted(HIVE_SERVER2_1_CONTAINER.getMappedPort(RANDOM_PORT_FIRST));
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName("org.apache.hive.jdbc.HiveDriver");
+        config.setJdbcUrl(jdbcUrlPrefix + jdbcUrlSuffix);
+        return new HikariDataSource(config);
+    }
+
+    private void extracted(final int hiveServer2Port) {
+        String connectionString = ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181);
+        await().atMost(Duration.ofMinutes(2L)).ignoreExceptions().until(() -> {
+            try (CuratorFramework client = CuratorFrameworkFactory.builder().connectString(connectionString)
+                    .retryPolicy(new ExponentialBackoffRetry(1000, 3)).build()) {
+                client.start();
+                List<String> children = client.getChildren().forPath("/hiveserver2");
+                assertThat(children.size(), is(1));
+                return children.get(0).contains(":" + hiveServer2Port + ";version=");
+            }
+        });
+        await().atMost(Duration.ofMinutes(1L)).ignoreExceptions().until(() -> {
+            openConnection().close();
+            return true;
+        });
+    }
+
+    private static int getRandomPort() {
+        try (ServerSocket server = new ServerSocket(0)) {
+            server.setReuseAddress(true);
+            return server.getLocalPort();
+        } catch (IOException exception) {
+            throw new Error(exception);
+        }
+    }
+}

--- a/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
+++ b/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/com.github.docker-java/docker-java-api/3.4.0/reflect-config.json
@@ -1,7 +1,676 @@
 [
 {
-  "condition":{"typeReachable":"com.github.dockerjava.api.model.RuntimeInfo"},
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Bind;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Capability;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Device;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.ExposedPort;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Link;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.LxcConf;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.PortBinding;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Ports$Binding;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Ulimit;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.Volume;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumeBind;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumeRW;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lcom.github.dockerjava.api.model.VolumesFrom;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Ljava.lang.String;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"[Lorg.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.CreateContainerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.CreateContainerResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setId","parameterTypes":["java.lang.String"] }, {"name":"setWarnings","parameterTypes":["java.lang.String[]"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.DockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.GraphData",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.GraphDriver",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.HealthState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.HealthStateLog",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$ContainerState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "queryAllPublicConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":["com.github.dockerjava.api.command.InspectContainerResponse"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$Mount",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectContainerResponse$Node",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.InspectImageResponse",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.RootFS",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.command.SyncDockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.AccessMode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.AuthConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Bind",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BindOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BindPropagation",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Binds",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.lang.String[]"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BlkioRateDevice",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.BlkioWeightDevice",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Capability",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ClusterInfo",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerNetwork",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "allPublicMethods": true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ContainerNetwork$Ipam",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Device",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.DeviceRequest",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.DockerObject",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"getRawValues","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Driver",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExposedPort",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExposedPorts",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.util.Map"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExternalCA",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ExternalCAProtocol",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.HealthCheck",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.HostConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"getAutoRemove","parameterTypes":[] }, {"name":"getBlkioDeviceReadBps","parameterTypes":[] }, {"name":"getBlkioDeviceReadIOps","parameterTypes":[] }, {"name":"getBlkioDeviceWriteBps","parameterTypes":[] }, {"name":"getBlkioDeviceWriteIOps","parameterTypes":[] }, {"name":"getBlkioWeight","parameterTypes":[] }, {"name":"getBlkioWeightDevice","parameterTypes":[] }, {"name":"getCapAdd","parameterTypes":[] }, {"name":"getCapDrop","parameterTypes":[] }, {"name":"getCgroup","parameterTypes":[] }, {"name":"getCgroupParent","parameterTypes":[] }, {"name":"getCgroupnsMode","parameterTypes":[] }, {"name":"getConsoleSize","parameterTypes":[] }, {"name":"getContainerIDFile","parameterTypes":[] }, {"name":"getCpuCount","parameterTypes":[] }, {"name":"getCpuPercent","parameterTypes":[] }, {"name":"getCpuPeriod","parameterTypes":[] }, {"name":"getCpuQuota","parameterTypes":[] }, {"name":"getCpuRealtimePeriod","parameterTypes":[] }, {"name":"getCpuRealtimeRuntime","parameterTypes":[] }, {"name":"getCpuShares","parameterTypes":[] }, {"name":"getCpusetCpus","parameterTypes":[] }, {"name":"getCpusetMems","parameterTypes":[] }, {"name":"getDeviceCgroupRules","parameterTypes":[] }, {"name":"getDeviceRequests","parameterTypes":[] }, {"name":"getDevices","parameterTypes":[] }, {"name":"getDiskQuota","parameterTypes":[] }, {"name":"getDns","parameterTypes":[] }, {"name":"getDnsOptions","parameterTypes":[] }, {"name":"getDnsSearch","parameterTypes":[] }, {"name":"getExtraHosts","parameterTypes":[] }, {"name":"getGroupAdd","parameterTypes":[] }, {"name":"getInit","parameterTypes":[] }, {"name":"getIoMaximumBandwidth","parameterTypes":[] }, {"name":"getIoMaximumIOps","parameterTypes":[] }, {"name":"getIpcMode","parameterTypes":[] }, {"name":"getIsolation","parameterTypes":[] }, {"name":"getKernelMemory","parameterTypes":[] }, {"name":"getLxcConf","parameterTypes":[] }, {"name":"getMemory","parameterTypes":[] }, {"name":"getMemoryReservation","parameterTypes":[] }, {"name":"getMemorySwap","parameterTypes":[] }, {"name":"getMemorySwappiness","parameterTypes":[] }, {"name":"getMounts","parameterTypes":[] }, {"name":"getNanoCPUs","parameterTypes":[] }, {"name":"getNetworkMode","parameterTypes":[] }, {"name":"getOomKillDisable","parameterTypes":[] }, {"name":"getOomScoreAdj","parameterTypes":[] }, {"name":"getPidMode","parameterTypes":[] }, {"name":"getPidsLimit","parameterTypes":[] }, {"name":"getPortBindings","parameterTypes":[] }, {"name":"getPrivileged","parameterTypes":[] }, {"name":"getPublishAllPorts","parameterTypes":[] }, {"name":"getReadonlyRootfs","parameterTypes":[] }, {"name":"getRestartPolicy","parameterTypes":[] }, {"name":"getRuntime","parameterTypes":[] }, {"name":"getSecurityOpts","parameterTypes":[] }, {"name":"getShmSize","parameterTypes":[] }, {"name":"getStorageOpt","parameterTypes":[] }, {"name":"getSysctls","parameterTypes":[] }, {"name":"getTmpFs","parameterTypes":[] }, {"name":"getUlimits","parameterTypes":[] }, {"name":"getUsernsMode","parameterTypes":[] }, {"name":"getUtSMode","parameterTypes":[] }, {"name":"getVolumeDriver","parameterTypes":[] }, {"name":"getVolumesFrom","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Image",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Info",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InfoRegistryConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InfoRegistryConfig$IndexConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.InternetProtocol",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Isolation",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Link",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Links",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LocalNodeState",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"forValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LogConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setType","parameterTypes":["com.github.dockerjava.api.model.LogConfig$LoggingType"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LogConfig$LoggingType",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "methods":[{"name":"fromValue","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.LxcConf",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Mount",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.MountType",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.NetworkSettings",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.PeerNode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ports",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"fromPrimitive","parameterTypes":["java.util.Map"] }, {"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ports$Binding",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.PropagationMode",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.ResourceVersion",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.RestartPolicy",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
   "name":"com.github.dockerjava.api.model.RuntimeInfo",
-  "allPublicConstructors": true
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setPath","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SELContext",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmCAConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmDispatcherConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmInfo",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmOrchestration",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmRaftConfig",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.SwarmSpec",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.TaskDefaults",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.TmpfsOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Ulimit",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Version",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VersionComponent",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VersionPlatform",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Volume",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"<init>","parameterTypes":["java.lang.String"] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeBind",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeBinds",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeOptions",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumeRW",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.Volumes",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"toPrimitive","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumesFrom",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.DockerClientDelegate"},
+  "name":"com.github.dockerjava.api.model.VolumesRW",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.command.CreateNetworkCmd"},
+  "name":"com.github.dockerjava.api.command.CreateNetworkCmd",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.command.CreateNetworkResponse"},
+  "name":"com.github.dockerjava.api.command.CreateNetworkResponse",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.PullResponseItem",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$AuxDetail",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$ErrorDetail",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"com.github.dockerjava.api.model.ResponseItem$ProgressDetail",
+  "allDeclaredMethods": true
 }
 ]

--- a/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/resource-config.json
+++ b/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.apache.calcite/calcite-core/1.35.0/resource-config.json
@@ -1,0 +1,8 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.apache.calcite.avatica.remote.Driver"},
+    "pattern":"\\Qorg-apache-calcite-jdbc.properties\\E"
+  }]},
+  "bundles":[]
+}

--- a/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1/reflect-config.json
+++ b/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1/reflect-config.json
@@ -1,34 +1,88 @@
 [
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.LogFactory",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"}
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.LogFactory",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"}
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.impl.Jdk14Logger",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
-    "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}]
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"},
-    "methods": [{"name": "<init>", "parameterTypes": []}]
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"}
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.impl.SimpleLog",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
-    "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}]
-  },
-  {
-    "name": "org.apache.hive.org.apache.commons.logging.impl.WeakHashtable",
-    "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"},
-    "methods": [{"name": "<init>", "parameterTypes": []}]
-  }
+{
+  "name": "org.apache.hive.org.apache.commons.logging.LogFactory",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"}
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.LogFactory",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"}
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.impl.Jdk14Logger",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
+  "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}]
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"},
+  "methods": [{"name": "<init>", "parameterTypes": []}]
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"}
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.impl.SimpleLog",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
+  "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}]
+},
+{
+  "name": "org.apache.hive.org.apache.commons.logging.impl.WeakHashtable",
+  "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.LogFactory"},
+  "methods": [{"name": "<init>", "parameterTypes": []}]
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.ZooKeeper"},
+  "name":"org.apache.hive.org.apache.zookeeper.ClientCnxnSocketNIO",
+  "methods":[{"name":"<init>","parameterTypes":["org.apache.hive.org.apache.zookeeper.client.ZKClientConfig"] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.metrics.impl.MetricsProviderBootstrap"},
+  "name":"org.apache.hive.org.apache.zookeeper.metrics.impl.DefaultMetricsProvider",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.quorum.QuorumPeerConfig"},
+  "name":"org.apache.hive.org.apache.zookeeper.metrics.impl.DefaultMetricsProvider"
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.ConnectionBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.ConnectionMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.DataTreeBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.DataTreeMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ServerCnxnFactory"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.NIOServerCnxnFactory",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServerBean",
+  "queryAllPublicConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServer"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.ZooKeeperServerMXBean",
+  "queryAllPublicMethods":true
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.server.watch.WatchManagerFactory"},
+  "name":"org.apache.hive.org.apache.zookeeper.server.watch.WatchManager",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+}
 ]

--- a/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
+++ b/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/reflect-config.json
@@ -1,0 +1,195 @@
+[
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ArrayBuilders"},
+  "name":"[Lorg.testcontainers.shaded.com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.ClickHouseProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.MSSQLServerContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PgVectorContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PostgisContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.PostgreSQLContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+  "name":"org.testcontainers.containers.TimescaleDBContainerProvider"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.DockerDesktopClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.DockerMachineClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.NpipeSocketClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.RootlessDockerClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.TestcontainersHostPropertyClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+  "name":"org.testcontainers.dockerclient.UnixSocketClientProviderStrategy"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+  "name":"org.testcontainers.dockerclient.UnixSocketClientProviderStrategy",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7Support"},
+  "name":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile",
+  "allDeclaredFields":true,
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"setAuths","parameterTypes":["java.util.Map"] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig$Builder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.DockerConfigFile"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrAsyncDockerCmd",
+  "queryAllDeclaredMethods":true,
+  "allDeclaredFields": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateNetworkCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd",
+  "queryAllDeclaredMethods":true,
+  "allDeclaredFields": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.AbstrDockerCmd",
+  "queryAllDeclaredMethods":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.CreateNetworkCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateNetworkCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"getAttachable","parameterTypes":[] }, {"name":"getCheckDuplicate","parameterTypes":[] }, {"name":"getDriver","parameterTypes":[] }, {"name":"getEnableIPv6","parameterTypes":[] }, {"name":"getInternal","parameterTypes":[] }, {"name":"getIpam","parameterTypes":[] }, {"name":"getLabels","parameterTypes":[] }, {"name":"getName","parameterTypes":[] }, {"name":"getOptions","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.exec.ExecCreateCmdExec"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.ExecCreateCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true,
+  "methods":[{"name":"getContainerId","parameterTypes":[] }, {"name":"getEnv","parameterTypes":[] }, {"name":"getPrivileged","parameterTypes":[] }, {"name":"getUser","parameterTypes":[] }, {"name":"getWorkingDir","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.ExecStartCmdImpl",
+  "allDeclaredFields":true,
+  "queryAllDeclaredMethods":true,
+  "queryAllDeclaredConstructors":true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer$$Lambda/0x00007f841f23d008"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.hamcrest.TypeSafeMatcher"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.org.hamcrest.internal.ReflectiveTypeFinder"},
+  "name":"org.testcontainers.shaded.org.awaitility.core.ConditionFactory$1"
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.fasterxml.jackson.databind.util.ClassUtil"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl",
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.junit.jupiter.Testcontainers"},
+  "name":"org.testcontainers.junit.jupiter.Testcontainers",
+  "allPublicMethods": true
+},
+{
+  "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl"},
+  "name":"org.testcontainers.shaded.com.github.dockerjava.core.command.CreateContainerCmdImpl$NetworkingConfig",
+  "allDeclaredFields": true,
+  "allDeclaredMethods": true,
+  "allDeclaredConstructors": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$Ipam$Config",
+  "allDeclaredMethods": true
+},
+{
+  "condition":{"typeReachable":"com.github.dockerjava.api.model.Network"},
+  "name":"com.github.dockerjava.api.model.Network$ContainerNetworkConfig",
+  "allDeclaredMethods": true
+}
+]

--- a/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/resource-config.json
+++ b/hive-server2-jdbc-driver-uber/src/main/resources/META-INF/native-image/org.testcontainers/junit-jupiter/1.20.1/resource-config.json
@@ -1,0 +1,32 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.testcontainers.jdbc.ContainerDatabaseDriver"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.containers.GenericContainer"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.core.CreateContainerCmdModifier\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.DockerClientFactory"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.shaded.com.google.common.io.Resources"},
+    "pattern":"\\Qcontainer-license-acceptance.txt\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.containers.wait.strategy.HostPortWaitStrategy"},
+    "pattern":"\\Qlogback-test.xml\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.utility.ClasspathScanner"},
+    "pattern":"\\Qtestcontainers.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.utility.ImageNameSubstitutor"},
+    "pattern":"\\QMETA-INF/services/org.testcontainers.utility.ImageNameSubstitutor\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.shaded.com.github.dockerjava.core.DefaultDockerClientConfig"},
+    "pattern":"\\Qdocker-java.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.testcontainers.dockerclient.DockerClientProviderStrategy"},
+    "pattern":"\\QMETA-INF/services/java.net.spi.InetAddressResolverProvider\\E"
+  }]},
+  "bundles":[]
+}

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/HiveZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/HiveZookeeperServiceDiscoveryTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Qiheng He
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.linghengqian.hive.server2.jdbc.driver.uber;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.hive.org.apache.curator.framework.CuratorFramework;
+import org.apache.hive.org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.hive.org.apache.curator.retry.ExponentialBackoffRetry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.sql.*;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "resource", "deprecation"})
+@Testcontainers
+class HiveZookeeperServiceDiscoveryTest {
+
+    private static final int RANDOM_PORT_FIRST = getRandomPort();
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    @Container
+    private static final GenericContainer<?> ZOOKEEPER_CONTAINER = new GenericContainer<>("zookeeper:3.9.3-jre-17")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("foo")
+            .withExposedPorts(2181);
+
+    @Container
+    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+            .withNetwork(NETWORK)
+            .withEnv("SERVICE_NAME", "hiveserver2")
+            .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                    + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                    + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                    + "-Dhive.server2.thrift.port=" + RANDOM_PORT_FIRST)
+            .withFixedExposedPort(RANDOM_PORT_FIRST, RANDOM_PORT_FIRST)
+            .dependsOn(ZOOKEEPER_CONTAINER);
+
+    private final String jdbcUrlSuffix = ";serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2";
+
+    private String jdbcUrlPrefix;
+
+    @AfterAll
+    static void afterAll() {
+        NETWORK.close();
+    }
+
+    @Test
+    void assertShardingInLocalTransactions() throws SQLException {
+        jdbcUrlPrefix = "jdbc:hive2://" + ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181) + "/";
+        DataSource dataSource = createDataSource();
+        extracted(dataSource);
+        HIVE_SERVER2_1_CONTAINER.stop();
+        int randomPortSecond = getRandomPort();
+        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+                .withNetwork(NETWORK)
+                .withEnv("SERVICE_NAME", "hiveserver2")
+                .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
+                        + "-Dhive.zookeeper.quorum=" + ZOOKEEPER_CONTAINER.getNetworkAliases().get(0) + ":2181" + " "
+                        + "-Dhive.server2.thrift.bind.host=0.0.0.0" + " "
+                        + "-Dhive.server2.thrift.port=" + randomPortSecond)
+                .withFixedExposedPort(randomPortSecond, randomPortSecond)
+                .dependsOn(ZOOKEEPER_CONTAINER)) {
+            hiveServer2SecondContainer.start();
+            extracted(hiveServer2SecondContainer.getMappedPort(randomPortSecond));
+            extracted(dataSource);
+        }
+    }
+
+    private static void extracted(DataSource dataSource) throws SQLException {
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE demo_ds_0");
+            ResultSet firstResultSet = statement.executeQuery("show tables");
+            assertThat(firstResultSet.next(), is(false));
+            statement.execute("create table hive_example(a string, b int) partitioned by(c int)");
+            statement.execute("alter table hive_example add partition(c=1)");
+            statement.execute("insert into hive_example partition(c=1) values('a', 1), ('a', 2),('b',3)");
+            ResultSet secondResultSet = statement.executeQuery("select count(distinct a) from hive_example");
+            assertThat(secondResultSet.next(), is(true));
+            assertThat(secondResultSet.getInt("_c0"), is(2));
+            ResultSet thirdResultSet = statement.executeQuery("select sum(b) from hive_example");
+            assertThat(thirdResultSet.next(), is(true));
+            assertThat(thirdResultSet.getInt("_c0"), is(6));
+        }
+    }
+
+    private Connection openConnection() throws SQLException {
+        Properties props = new Properties();
+        return DriverManager.getConnection(jdbcUrlPrefix + jdbcUrlSuffix, props);
+    }
+
+    private DataSource createDataSource() {
+        extracted(HIVE_SERVER2_1_CONTAINER.getMappedPort(RANDOM_PORT_FIRST));
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName("org.apache.hive.jdbc.HiveDriver");
+        config.setJdbcUrl(jdbcUrlPrefix + jdbcUrlSuffix);
+        return new HikariDataSource(config);
+    }
+
+    private void extracted(final int hiveServer2Port) {
+        String connectionString = ZOOKEEPER_CONTAINER.getHost() + ":" + ZOOKEEPER_CONTAINER.getMappedPort(2181);
+        await().atMost(Duration.ofMinutes(2L)).ignoreExceptions().until(() -> {
+            try (CuratorFramework client = CuratorFrameworkFactory.builder().connectString(connectionString)
+                    .retryPolicy(new ExponentialBackoffRetry(1000, 3)).build()) {
+                client.start();
+                List<String> children = client.getChildren().forPath("/hiveserver2");
+                assertThat(children.size(), is(1));
+                return children.get(0).contains(":" + hiveServer2Port + ";version=");
+            }
+        });
+        await().atMost(Duration.ofMinutes(1L)).ignoreExceptions().until(() -> {
+            openConnection().close();
+            return true;
+        });
+    }
+
+    private static int getRandomPort() {
+        try (ServerSocket server = new ServerSocket(0)) {
+            server.setReuseAddress(true);
+            return server.getLocalPort();
+        } catch (IOException exception) {
+            throw new Error(exception);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,9 @@
                             <extensions>true</extensions>
                             <configuration>
                                 <quickBuild>true</quickBuild>
+                                <metadataRepository>
+                                    <version>0.3.14</version>
+                                </metadataRepository>
                             </configuration>
                             <executions>
                                 <execution>


### PR DESCRIPTION
- Support connecting to HiveServer2 with ZooKeeper Service Discovery enabled in GraalVM Native Image.
- Once again, the Uber JAR of the HiveServer2 JDBC Driver demonstrates amazing features. Why say once again?🫠🫠🫠🫠🫠
- For https://github.com/apache/shardingsphere/pull/33768 and https://github.com/oracle/graalvm-reachability-metadata/issues/377 .
- Also for https://github.com/testcontainers/testcontainers-java/issues/9553 and https://github.com/testcontainers/testcontainers-java/issues/9552 .