### PR TITLE
Removes unit test usage of `FixedHostPortGenericContainer`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     if: github.repository == 'linghengqian/hive-server2-jdbc-driver'
     strategy:
       matrix:
-        java: [ '8', '23' ]
+        java: [ '17', '23' ]
         os: [ 'ubuntu-latest' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HS2Container.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HS2Container.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 Qiheng He
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -7,8 +23,10 @@ import org.testcontainers.images.builder.Transferable;
 import java.io.IOException;
 import java.net.ServerSocket;
 
-@SuppressWarnings({"resource", "OctalInteger"})
+@SuppressWarnings({"resource"})
 public class HS2Container extends GenericContainer<HS2Container> {
+
+    String zookeeperConnectionString;
     private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
     private final int randomPortFirst = getRandomPort();
 
@@ -21,14 +39,18 @@ public class HS2Container extends GenericContainer<HS2Container> {
         );
     }
 
+    public HS2Container withZookeeperConnectionString(final String zookeeperConnectionString) {
+        this.zookeeperConnectionString = zookeeperConnectionString;
+        return self();
+    }
+
     @Override
     protected void containerIsStarting(InspectContainerResponse containerInfo) {
-        Integer mappedPort = getMappedPort(randomPortFirst);
         String command = """
                 #!/bin/bash
-                export SERVICE_OPTS='-Dhive.server2.support.dynamic.service.discovery=true -Dhive.zookeeper.quorum=foo:2181 -Dhive.server2.thrift.bind.host=0.0.0.0 -Dhive.server2.thrift.port=%s'
-                /usr/local/bin/docker-entrypoint.sh
-                """.formatted(mappedPort);
+                export SERVICE_OPTS="-Dhive.server2.support.dynamic.service.discovery=true -Dhive.zookeeper.quorum=%s -Dhive.server2.thrift.bind.host=0.0.0.0 -Dhive.server2.thrift.port=%s"
+                /entrypoint.sh
+                """.formatted(zookeeperConnectionString, getMappedPort(randomPortFirst));
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
     }
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HS2Container.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/HS2Container.java
@@ -1,0 +1,43 @@
+package io.github.linghengqian.hive.server2.jdbc.driver.thin;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+@SuppressWarnings({"resource", "OctalInteger"})
+public class HS2Container extends GenericContainer<HS2Container> {
+    private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
+    private final int randomPortFirst = getRandomPort();
+
+    public HS2Container(final String dockerImageName) {
+        super(dockerImageName);
+        withEnv("SERVICE_NAME", "hiveserver2");
+        withExposedPorts(randomPortFirst);
+        withCreateContainerCmdModifier(cmd ->
+                cmd.withEntrypoint("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT)
+        );
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+        Integer mappedPort = getMappedPort(randomPortFirst);
+        String command = """
+                #!/bin/bash
+                export SERVICE_OPTS='-Dhive.server2.support.dynamic.service.discovery=true -Dhive.zookeeper.quorum=foo:2181 -Dhive.server2.thrift.bind.host=0.0.0.0 -Dhive.server2.thrift.port=%s'
+                /usr/local/bin/docker-entrypoint.sh
+                """.formatted(mappedPort);
+        copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+    }
+
+    private int getRandomPort() {
+        try (ServerSocket server = new ServerSocket(0)) {
+            server.setReuseAddress(true);
+            return server.getLocalPort();
+        } catch (IOException exception) {
+            throw new Error(exception);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </scm>
 
     <properties>
-        <maven.compiler.release>8</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <apache-hive-jdbc.version>4.0.1</apache-hive-jdbc.version>


### PR DESCRIPTION
- For https://github.com/testcontainers/testcontainers-java/issues/9553 .
- Removes unit test usage of `FixedHostPortGenericContainer`.