### PR TITLE
Add Maven Profile for initial generation of GraalVM Reachability Metadata JSON

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -20,6 +20,17 @@ sdk use java 22.0.2-graalce
 ./mvnw -T 1.5C clean test
 ```
 
+### How to initially generate the JSON for GraalVM Reachability Metadata
+
+- Execute the following command.
+
+```shell
+git clone git@github.com:linghengqian/hive-server2-jdbc-driver.git -b add-agent
+cd ./hive-server2-jdbc-driver/
+sdk use java 22.0.2-graalce
+./mvnw -PgenerateMetadata -DskipNativeTests clean test native:metadata-copy
+```
+
 ### How to nativeTest under GraalVM Native Image
 
 - Execute the following command.

--- a/native-image-filter/extra-filter.json
+++ b/native-image-filter/extra-filter.json
@@ -1,0 +1,9 @@
+{
+  "rules": [
+    {"includeClasses": "**"},
+
+    {"excludeClasses": "io.github.linghengqian.hive.server2.jdbc.driver.**"}
+  ],
+  "regexRules": [
+  ]
+}

--- a/native-image-filter/user-code-filter.json
+++ b/native-image-filter/user-code-filter.json
@@ -1,0 +1,8 @@
+{
+  "rules": [
+    {"excludeClasses": "**"},
+    {"includeClasses": "org.apache.hive.**"}
+  ],
+  "regexRules": [
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,57 @@
             </build>
         </profile>
         <profile>
+            <id>generateMetadata</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.graalvm.buildtools</groupId>
+                            <artifactId>native-maven-plugin</artifactId>
+                            <version>${native-maven-plugin.version}</version>
+                            <extensions>true</extensions>
+                            <configuration>
+                                <agent>
+                                    <enabled>true</enabled>
+                                    <defaultMode>Conditional</defaultMode>
+                                    <modes>
+                                        <conditional>
+                                            <userCodeFilterPath>${user.dir}/native-image-filter/user-code-filter.json</userCodeFilterPath>
+                                            <extraFilterPath>${user.dir/native-image-filter/extra-filter.json</extraFilterPath>
+                                            <parallel>true</parallel>
+                                        </conditional>
+                                    </modes>
+                                    <metadataCopy>
+                                        <disabledStages>
+                                            <stage>main</stage>
+                                        </disabledStages>
+                                        <merge>false</merge>
+                                        <outputDirectory>${user.dir}/generated-reachability-metadata/</outputDirectory>
+                                    </metadataCopy>
+                                </agent>
+                            </configuration>
+                            <executions>
+                                <execution>
+                                    <id>build-native</id>
+                                    <goals>
+                                        <goal>compile-no-fork</goal>
+                                    </goals>
+                                    <phase>package</phase>
+                                </execution>
+                                <execution>
+                                    <id>test-native</id>
+                                    <goals>
+                                        <goal>test</goal>
+                                    </goals>
+                                    <phase>test</phase>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
             <id>nativeTestInCustom</id>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
- For https://github.com/apache/shardingsphere/issues/29052 .
- Add Maven Profile for initial generation of GraalVM Reachability Metadata JSON.
- **Warning, the current PR discovered unknown issues with GraalVM Native Build Tools 0.10.4.**