### PR TITLE
Add unit tests for `information_schema` database with custom tables

### DIFF
--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
@@ -49,39 +49,20 @@ public class InformationSchemaTest {
             .withNetworkAliases("some-postgres");
 
     @Container
-    public static final GenericContainer<?> HMS = new GenericContainer<>(
-            new ImageFromDockerfile().withFileFromPath(
-                    "Dockerfile",
-                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
-            )
-    )
-            .withEnv("SERVICE_NAME", "metastore")
-            .withEnv("DB_DRIVER", "postgres")
-            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
-                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionPassword=example")
-            .withNetwork(NETWORK)
-            .withNetworkAliases("metastore-standalone")
-            .dependsOn(POSTGRES);
-
-    @Container
     public static final GenericContainer<?> HS2 = new GenericContainer<>(
             new ImageFromDockerfile().withFileFromPath(
                     "Dockerfile",
                     Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
             ))
             .withEnv("SERVICE_NAME", "hiveserver2")
-            .withEnv("IS_RESUME", "true")
+            .withEnv("DB_DRIVER", "postgres")
             .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
                     "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
                     "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionPassword=example" + " " +
-                    "-Dhive.metastore.uris=thrift://metastore-standalone:9083")
+                    "-Djavax.jdo.option.ConnectionPassword=example")
             .withNetwork(NETWORK)
-            .dependsOn(HMS)
-            .withExposedPorts(10000)
-            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
+            .dependsOn(POSTGRES)
+            .withExposedPorts(10000);
 
 
     @AfterAll

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
@@ -16,13 +16,17 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.sql.*;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -32,21 +36,62 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * TODO This unit test is affected by <a href="https://github.com/apache/hive/pull/5629">apache/hive#5629</a>,
- *  the `information_schema` database does not exist by default.
- */
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
 public class InformationSchemaTest {
+
+    private static final Network NETWORK = Network.newNetwork();
+
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+            .withEnv("POSTGRES_PASSWORD", "example")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("some-postgres");
+
+    @Container
+    public static final GenericContainer<?> HMS = new GenericContainer<>(
+            new ImageFromDockerfile().withFileFromPath(
+                    "Dockerfile",
+                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
+            )
+    )
+            .withEnv("SERVICE_NAME", "metastore")
+            .withEnv("DB_DRIVER", "postgres")
+            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
+                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionPassword=example")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("metastore-standalone")
+            .dependsOn(POSTGRES);
+
+    @Container
+    public static final GenericContainer<?> HS2 = new GenericContainer<>(
+            new ImageFromDockerfile().withFileFromPath(
+                    "Dockerfile",
+                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
+            ))
             .withEnv("SERVICE_NAME", "hiveserver2")
-            .withExposedPorts(10000);
+            .withEnv("IS_RESUME", "true")
+            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
+                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionPassword=example" + " " +
+                    "-Dhive.metastore.uris=thrift://metastore-standalone:9083")
+            .withNetwork(NETWORK)
+            .dependsOn(HMS)
+            .withExposedPorts(10000)
+            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
+
+
+    @AfterAll
+    static void afterAll() {
+        NETWORK.close();
+    }
 
     @Test
     void test() throws SQLException, IOException, InterruptedException {
-        String jdbcUrlPrefix = "jdbc:hive2://" + CONTAINER.getHost() + ":" + CONTAINER.getMappedPort(10000);
+        String jdbcUrlPrefix = "jdbc:hive2://" + HS2.getHost() + ":" + HS2.getMappedPort(10000);
         await().atMost(Duration.of(30L, ChronoUnit.SECONDS)).ignoreExceptions().until(() -> {
             DriverManager.getConnection(jdbcUrlPrefix).close();
             return true;
@@ -69,23 +114,14 @@ public class InformationSchemaTest {
             statement.executeUpdate("INSERT INTO t_order (order_id, user_id, order_type, address_id, status) VALUES (1, 1, 1, 1, 'INSERT_TEST')");
             ResultSet resultSet = statement.executeQuery("select * from t_order");
             assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.next(), is(false));
         }
         assertThrows(SQLException.class, () -> DriverManager.getConnection(jdbcUrlPrefix + "/information_schema").close());
-        ExecResult infoResult = CONTAINER.execInContainer(
-                "/opt/hive/bin/schematool",
-                "-info",
-                "-dbType", "hive",
-                "-metaDbType", "derby",
-                "-url", "jdbc:hive2://localhost:10000/default"
-        );
-        assertThat(infoResult.getStdout(), is("Metastore connection URL:\t jdbc:hive2://localhost:10000/default\n" +
-                "Metastore connection Driver :\t org.apache.hive.jdbc.HiveDriver\n" +
-                "Metastore connection User:\t APP\n"));
-        ExecResult initResult = CONTAINER.execInContainer(
+        ExecResult initResult = HS2.execInContainer(
                 "/opt/hive/bin/schematool",
                 "-initSchema",
                 "-dbType", "hive",
-                "-metaDbType", "derby",
+                "-metaDbType", "postgres",
                 "-url", "jdbc:hive2://localhost:10000/default"
         );
         assertThat(initResult.getStdout(), is("Initializing the schema to: 4.0.0\n" +
@@ -97,7 +133,17 @@ public class InformationSchemaTest {
                 "Initialization script completed\n"));
         try (Connection connection = DriverManager.getConnection(jdbcUrlPrefix + "/information_schema");
              Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery("select * from information_schema.COLUMNS limit 100");
+            ResultSet resultSet = statement.executeQuery("select TABLE_CATALOG,\n" +
+                    "       TABLE_NAME,\n" +
+                    "       COLUMN_NAME,\n" +
+                    "       DATA_TYPE,\n" +
+                    "       ORDINAL_POSITION,\n" +
+                    "       IS_NULLABLE\n" +
+                    "FROM INFORMATION_SCHEMA.COLUMNS\n" +
+                    "WHERE TABLE_CATALOG = 'default'\n" +
+                    "  AND TABLE_SCHEMA = 'demo_ds_0'\n" +
+                    "  AND UPPER(TABLE_NAME) IN ('T_ORDER')\n" +
+                    "ORDER BY ORDINAL_POSITION limit 100");
             assertThat(resultSet.next(), is(true));
         }
     }

--- a/hive-server2-jdbc-driver-thin/src/test/resources/information-schema/Dockerfile
+++ b/hive-server2-jdbc-driver-thin/src/test/resources/information-schema/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2025 Qiheng He
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.21.2 AS prepare
+RUN apk add --no-cache wget
+RUN wget https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.5/postgresql-42.7.5.jar --directory-prefix=/opt/hive/lib
+FROM apache/hive:4.0.1
+COPY --from=prepare /opt/hive/lib /opt/hive/lib

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
@@ -49,39 +49,20 @@ public class InformationSchemaTest {
             .withNetworkAliases("some-postgres");
 
     @Container
-    public static final GenericContainer<?> HMS = new GenericContainer<>(
-            new ImageFromDockerfile().withFileFromPath(
-                    "Dockerfile",
-                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
-            )
-    )
-            .withEnv("SERVICE_NAME", "metastore")
-            .withEnv("DB_DRIVER", "postgres")
-            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
-                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionPassword=example")
-            .withNetwork(NETWORK)
-            .withNetworkAliases("metastore-standalone")
-            .dependsOn(POSTGRES);
-
-    @Container
     public static final GenericContainer<?> HS2 = new GenericContainer<>(
             new ImageFromDockerfile().withFileFromPath(
                     "Dockerfile",
                     Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
             ))
             .withEnv("SERVICE_NAME", "hiveserver2")
-            .withEnv("IS_RESUME", "true")
+            .withEnv("DB_DRIVER", "postgres")
             .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
                     "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
                     "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
-                    "-Djavax.jdo.option.ConnectionPassword=example" + " " +
-                    "-Dhive.metastore.uris=thrift://metastore-standalone:9083")
+                    "-Djavax.jdo.option.ConnectionPassword=example")
             .withNetwork(NETWORK)
-            .dependsOn(HMS)
-            .withExposedPorts(10000)
-            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
+            .dependsOn(POSTGRES)
+            .withExposedPorts(10000);
 
 
     @AfterAll

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
@@ -16,13 +16,17 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.sql.*;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -32,21 +36,62 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * TODO This unit test is affected by <a href="https://github.com/apache/hive/pull/5629">apache/hive#5629</a>,
- *  the `information_schema` database does not exist by default.
- */
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
 public class InformationSchemaTest {
+
+    private static final Network NETWORK = Network.newNetwork();
+
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+            .withEnv("POSTGRES_PASSWORD", "example")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("some-postgres");
+
+    @Container
+    public static final GenericContainer<?> HMS = new GenericContainer<>(
+            new ImageFromDockerfile().withFileFromPath(
+                    "Dockerfile",
+                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
+            )
+    )
+            .withEnv("SERVICE_NAME", "metastore")
+            .withEnv("DB_DRIVER", "postgres")
+            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
+                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionPassword=example")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("metastore-standalone")
+            .dependsOn(POSTGRES);
+
+    @Container
+    public static final GenericContainer<?> HS2 = new GenericContainer<>(
+            new ImageFromDockerfile().withFileFromPath(
+                    "Dockerfile",
+                    Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
+            ))
             .withEnv("SERVICE_NAME", "hiveserver2")
-            .withExposedPorts(10000);
+            .withEnv("IS_RESUME", "true")
+            .withEnv("SERVICE_OPTS", "-Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver" + " " +
+                    "-Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionUserName=postgres" + " " +
+                    "-Djavax.jdo.option.ConnectionPassword=example" + " " +
+                    "-Dhive.metastore.uris=thrift://metastore-standalone:9083")
+            .withNetwork(NETWORK)
+            .dependsOn(HMS)
+            .withExposedPorts(10000)
+            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
+
+
+    @AfterAll
+    static void afterAll() {
+        NETWORK.close();
+    }
 
     @Test
     void test() throws SQLException, IOException, InterruptedException {
-        String jdbcUrlPrefix = "jdbc:hive2://" + CONTAINER.getHost() + ":" + CONTAINER.getMappedPort(10000);
+        String jdbcUrlPrefix = "jdbc:hive2://" + HS2.getHost() + ":" + HS2.getMappedPort(10000);
         await().atMost(Duration.of(30L, ChronoUnit.SECONDS)).ignoreExceptions().until(() -> {
             DriverManager.getConnection(jdbcUrlPrefix).close();
             return true;
@@ -69,23 +114,14 @@ public class InformationSchemaTest {
             statement.executeUpdate("INSERT INTO t_order (order_id, user_id, order_type, address_id, status) VALUES (1, 1, 1, 1, 'INSERT_TEST')");
             ResultSet resultSet = statement.executeQuery("select * from t_order");
             assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.next(), is(false));
         }
         assertThrows(SQLException.class, () -> DriverManager.getConnection(jdbcUrlPrefix + "/information_schema").close());
-        ExecResult infoResult = CONTAINER.execInContainer(
-                "/opt/hive/bin/schematool",
-                "-info",
-                "-dbType", "hive",
-                "-metaDbType", "derby",
-                "-url", "jdbc:hive2://localhost:10000/default"
-        );
-        assertThat(infoResult.getStdout(), is("Metastore connection URL:\t jdbc:hive2://localhost:10000/default\n" +
-                "Metastore connection Driver :\t org.apache.hive.jdbc.HiveDriver\n" +
-                "Metastore connection User:\t APP\n"));
-        ExecResult initResult = CONTAINER.execInContainer(
+        ExecResult initResult = HS2.execInContainer(
                 "/opt/hive/bin/schematool",
                 "-initSchema",
                 "-dbType", "hive",
-                "-metaDbType", "derby",
+                "-metaDbType", "postgres",
                 "-url", "jdbc:hive2://localhost:10000/default"
         );
         assertThat(initResult.getStdout(), is("Initializing the schema to: 4.0.0\n" +
@@ -97,7 +133,17 @@ public class InformationSchemaTest {
                 "Initialization script completed\n"));
         try (Connection connection = DriverManager.getConnection(jdbcUrlPrefix + "/information_schema");
              Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery("select * from information_schema.COLUMNS limit 100");
+            ResultSet resultSet = statement.executeQuery("select TABLE_CATALOG,\n" +
+                    "       TABLE_NAME,\n" +
+                    "       COLUMN_NAME,\n" +
+                    "       DATA_TYPE,\n" +
+                    "       ORDINAL_POSITION,\n" +
+                    "       IS_NULLABLE\n" +
+                    "FROM INFORMATION_SCHEMA.COLUMNS\n" +
+                    "WHERE TABLE_CATALOG = 'default'\n" +
+                    "  AND TABLE_SCHEMA = 'demo_ds_0'\n" +
+                    "  AND UPPER(TABLE_NAME) IN ('T_ORDER')\n" +
+                    "ORDER BY ORDINAL_POSITION limit 100");
             assertThat(resultSet.next(), is(true));
         }
     }

--- a/hive-server2-jdbc-driver-uber/src/test/resources/information-schema/Dockerfile
+++ b/hive-server2-jdbc-driver-uber/src/test/resources/information-schema/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2025 Qiheng He
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.21.2 AS prepare
+RUN apk add --no-cache wget
+RUN wget https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.5/postgresql-42.7.5.jar --directory-prefix=/opt/hive/lib
+FROM apache/hive:4.0.1
+COPY --from=prepare /opt/hive/lib /opt/hive/lib


### PR DESCRIPTION
- For #21 .
- Add unit tests for `information_schema` database with custom tables.
- ~Unfortunately, the unit test designed in this way seemed to trigger a bug in Hive, and I had to stop working on merging the PR. See https://github.com/apache/hive/pull/5629 .~ Fixed.

```yaml
services:
  some-postgres:
    image: postgres:17.2-bookworm
    environment:
      POSTGRES_PASSWORD: "example"
  hiveserver2-standalone:
    image: apache/hive:4.0.1
    depends_on:
      - some-postgres
    environment:
      SERVICE_NAME: hiveserver2
      DB_DRIVER: postgres
      SERVICE_OPTS: >-
        -Djavax.jdo.option.ConnectionDriverName=org.postgresql.Driver
        -Djavax.jdo.option.ConnectionURL=jdbc:postgresql://some-postgres:5432/postgres
        -Djavax.jdo.option.ConnectionUserName=postgres
        -Djavax.jdo.option.ConnectionPassword=example
    volumes:
      - ~/.m2/repository/org/postgresql/postgresql/42.7.5/postgresql-42.7.5.jar:/opt/hive/lib/postgres.jar
    ports:
      - "10000:10000"
      - "10002:10002"
```