### PR TITLE
Refactor use of `org.testcontainers.containers.Network`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,5 +60,8 @@ jobs:
           distribution: 'graalvm-community'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
+          native-image-job-reports: 'true'
+          native-image-pr-reports: 'true'
+          native-image-pr-reports-update-existing: 'true'
       - run: |
           ./mvnw -T 1.5C -PnativeTestInCustom clean test

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/AcidTableTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/AcidTableTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class AcidTableTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
@@ -16,7 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
@@ -40,16 +40,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Testcontainers
 public class InformationSchemaTest {
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+    @AutoClose
+    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
             .withEnv("POSTGRES_PASSWORD", "example")
             .withNetwork(NETWORK)
             .withNetworkAliases("some-postgres");
 
     @Container
-    public static final GenericContainer<?> HS2 = new GenericContainer<>(
+    @AutoClose
+    private static final GenericContainer<?> HS2 = new GenericContainer<>(
             new ImageFromDockerfile().withFileFromPath(
                     "Dockerfile",
                     Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
@@ -63,12 +66,6 @@ public class InformationSchemaTest {
             .withNetwork(NETWORK)
             .dependsOn(POSTGRES)
             .withExposedPorts(10000);
-
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void test() throws SQLException, IOException, InterruptedException {

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
@@ -19,7 +19,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -41,27 +41,25 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class StandaloneMetastoreTest {
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
+    @AutoClose
+    private static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "metastore")
             .withNetwork(NETWORK)
             .withNetworkAliases("metastore")
             .withExposedPorts(9083);
 
     @Container
-    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
+    @AutoClose
+    private static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.metastore.uris=thrift://metastore:9083")
             .withNetwork(NETWORK)
             .withExposedPorts(10000)
             .dependsOn(HMS_CONTAINER);
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void test() throws SQLException {

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -43,14 +44,14 @@ public class StandaloneMetastoreTest {
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "metastore")
             .withNetwork(NETWORK)
             .withNetworkAliases("metastore")
             .withExposedPorts(9083);
 
     @Container
-    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.metastore.uris=thrift://metastore:9083")
             .withNetwork(NETWORK)

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ThinTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ThinTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,7 +40,7 @@ import static org.hamcrest.Matchers.is;
 public class ThinTest {
 
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
@@ -22,7 +22,7 @@ import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -47,15 +47,18 @@ class ZookeeperServiceDiscoveryTest {
 
     private static final int RANDOM_PORT_FIRST = getRandomPort();
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
+    @AutoClose
     private static final GenericContainer<?> ZOOKEEPER_CONTAINER = new GenericContainer<>("zookeeper:3.9.3-jre-17")
             .withNetwork(NETWORK)
             .withNetworkAliases("foo")
             .withExposedPorts(2181);
 
     @Container
+    @AutoClose
     private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withNetwork(NETWORK)
             .withEnv("SERVICE_NAME", "hiveserver2")
@@ -69,11 +72,6 @@ class ZookeeperServiceDiscoveryTest {
     private final String jdbcUrlSuffix = ";serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2";
 
     private String jdbcUrlPrefix;
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void assertShardingInLocalTransactions() throws SQLException {

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
@@ -55,7 +56,7 @@ class ZookeeperServiceDiscoveryTest {
             .withExposedPorts(2181);
 
     @Container
-    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withNetwork(NETWORK)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
@@ -81,7 +82,7 @@ class ZookeeperServiceDiscoveryTest {
         extracted(dataSource);
         HIVE_SERVER2_1_CONTAINER.stop();
         int randomPortSecond = getRandomPort();
-        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
                 .withNetwork(NETWORK)
                 .withEnv("SERVICE_NAME", "hiveserver2")
                 .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/AvroTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/AvroTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class AvroTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/OrcTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/OrcTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class OrcTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/ParquetTest.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/iceberg/ParquetTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.thin.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class ParquetTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/util/ImageUtils.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/util/ImageUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Qiheng He
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.linghengqian.hive.server2.jdbc.driver.thin.util;
 
 public class ImageUtils {

--- a/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/util/ImageUtils.java
+++ b/hive-server2-jdbc-driver-thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/util/ImageUtils.java
@@ -1,0 +1,6 @@
+package io.github.linghengqian.hive.server2.jdbc.driver.thin.util;
+
+public class ImageUtils {
+
+    public static final String HIVE_IMAGE = "apache/hive:4.0.1";
+}

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/AcidTableTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/AcidTableTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class AcidTableTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
@@ -16,7 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
@@ -40,16 +40,19 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Testcontainers
 public class InformationSchemaTest {
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+    @AutoClose
+    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
             .withEnv("POSTGRES_PASSWORD", "example")
             .withNetwork(NETWORK)
             .withNetworkAliases("some-postgres");
 
     @Container
-    public static final GenericContainer<?> HS2 = new GenericContainer<>(
+    @AutoClose
+    private static final GenericContainer<?> HS2 = new GenericContainer<>(
             new ImageFromDockerfile().withFileFromPath(
                     "Dockerfile",
                     Paths.get("src/test/resources/information-schema/Dockerfile").toAbsolutePath()
@@ -63,12 +66,6 @@ public class InformationSchemaTest {
             .withNetwork(NETWORK)
             .dependsOn(POSTGRES)
             .withExposedPorts(10000);
-
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void test() throws SQLException, IOException, InterruptedException {

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -43,14 +44,14 @@ public class StandaloneMetastoreTest {
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "metastore")
             .withNetwork(NETWORK)
             .withNetworkAliases("metastore")
             .withExposedPorts(9083);
 
     @Container
-    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.metastore.uris=thrift://metastore:9083")
             .withNetwork(NETWORK)

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
@@ -19,7 +19,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -41,27 +41,25 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class StandaloneMetastoreTest {
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
-    public static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
+    @AutoClose
+    private static final GenericContainer<?> HMS_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "metastore")
             .withNetwork(NETWORK)
             .withNetworkAliases("metastore")
             .withExposedPorts(9083);
 
     @Container
-    public static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
+    @AutoClose
+    private static final GenericContainer<?> HS2_CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.metastore.uris=thrift://metastore:9083")
             .withNetwork(NETWORK)
             .withExposedPorts(10000)
             .dependsOn(HMS_CONTAINER);
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void test() throws SQLException {

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/UberTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/UberTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,7 +40,7 @@ import static org.hamcrest.Matchers.is;
 public class UberTest {
 
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.apache.hive.org.apache.curator.framework.CuratorFramework;
 import org.apache.hive.org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.hive.org.apache.curator.retry.ExponentialBackoffRetry;
@@ -55,7 +56,7 @@ class ZookeeperServiceDiscoveryTest {
             .withExposedPorts(2181);
 
     @Container
-    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+    private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withNetwork(NETWORK)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "
@@ -81,7 +82,7 @@ class ZookeeperServiceDiscoveryTest {
         extracted(dataSource);
         HIVE_SERVER2_1_CONTAINER.stop();
         int randomPortSecond = getRandomPort();
-        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>("apache/hive:4.0.1")
+        try (GenericContainer<?> hiveServer2SecondContainer = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
                 .withNetwork(NETWORK)
                 .withEnv("SERVICE_NAME", "hiveserver2")
                 .withEnv("SERVICE_OPTS", "-Dhive.server2.support.dynamic.service.discovery=true" + " "

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
@@ -22,7 +22,7 @@ import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.apache.hive.org.apache.curator.framework.CuratorFramework;
 import org.apache.hive.org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.hive.org.apache.curator.retry.ExponentialBackoffRetry;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -47,15 +47,18 @@ class ZookeeperServiceDiscoveryTest {
 
     private static final int RANDOM_PORT_FIRST = getRandomPort();
 
+    @AutoClose
     private static final Network NETWORK = Network.newNetwork();
 
     @Container
+    @AutoClose
     private static final GenericContainer<?> ZOOKEEPER_CONTAINER = new GenericContainer<>("zookeeper:3.9.3-jre-17")
             .withNetwork(NETWORK)
             .withNetworkAliases("foo")
             .withExposedPorts(2181);
 
     @Container
+    @AutoClose
     private static final GenericContainer<?> HIVE_SERVER2_1_CONTAINER = new FixedHostPortGenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withNetwork(NETWORK)
             .withEnv("SERVICE_NAME", "hiveserver2")
@@ -69,11 +72,6 @@ class ZookeeperServiceDiscoveryTest {
     private final String jdbcUrlSuffix = ";serviceDiscoveryMode=zooKeeper;zooKeeperNamespace=hiveserver2";
 
     private String jdbcUrlPrefix;
-
-    @AfterAll
-    static void afterAll() {
-        NETWORK.close();
-    }
 
     @Test
     void assertShardingInLocalTransactions() throws SQLException {

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/AvroTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/AvroTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class AvroTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/OrcTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/OrcTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class OrcTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/ParquetTest.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/iceberg/ParquetTest.java
@@ -16,6 +16,7 @@
 
 package io.github.linghengqian.hive.server2.jdbc.driver.uber.iceberg;
 
+import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 @Testcontainers
 public class ParquetTest {
     @Container
-    public static final GenericContainer<?> CONTAINER = new GenericContainer<>("apache/hive:4.0.1")
+    public static final GenericContainer<?> CONTAINER = new GenericContainer<>(ImageUtils.HIVE_IMAGE)
             .withEnv("SERVICE_NAME", "hiveserver2")
             .withExposedPorts(10000);
 

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/util/ImageUtils.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/util/ImageUtils.java
@@ -1,0 +1,6 @@
+package io.github.linghengqian.hive.server2.jdbc.driver.uber.util;
+
+public class ImageUtils {
+
+    public static final String HIVE_IMAGE = "apache/hive:4.0.1";
+}

--- a/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/util/ImageUtils.java
+++ b/hive-server2-jdbc-driver-uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/util/ImageUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 Qiheng He
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.linghengqian.hive.server2.jdbc.driver.uber.util;
 
 public class ImageUtils {

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         -->
         <stax2-api.version>4.2.1</stax2-api.version>
 
-        <junit-bom.version>5.12.0</junit-bom.version>
+        <junit-bom.version>5.11.2</junit-bom.version>
         <testcontainers-bom.version>1.20.5</testcontainers-bom.version>
         <hikaricp.version>4.0.3</hikaricp.version>
         <awaitility.version>4.3.0</awaitility.version>
@@ -84,7 +84,7 @@
         <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.5.0</central-publishing-maven-plugin.version>
-        <native-maven-plugin.version>0.10.4</native-maven-plugin.version>
+        <native-maven-plugin.version>0.10.5</native-maven-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
         -->
         <stax2-api.version>4.2.1</stax2-api.version>
 
-        <junit-bom.version>5.11.2</junit-bom.version>
-        <testcontainers-bom.version>1.20.2</testcontainers-bom.version>
+        <junit-bom.version>5.12.0</junit-bom.version>
+        <testcontainers-bom.version>1.20.5</testcontainers-bom.version>
         <hikaricp.version>4.0.3</hikaricp.version>
-        <awaitility.version>4.2.2</awaitility.version>
+        <awaitility.version>4.3.0</awaitility.version>
 
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>


### PR DESCRIPTION
- Refactor use of `org.testcontainers.containers.Network`.
- For https://github.com/testcontainers/testcontainers-java/issues/9552 .