### PR TITLE
Bump GraalVM Native Build Tools to 0.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,4 +105,4 @@ jobs:
           cache: 'maven'
           native-image-job-reports: 'true'
       - name: NativeTest on Oracle GraalVM For JDK ${{ matrix.java }}
-        run: ./mvnw -T 1.5C -PnativeTestInCustom clean test
+        run: ./mvnw -PnativeTestInCustom clean test

--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,7 @@
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
         <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
-        <native-maven-plugin.version>0.10.6</native-maven-plugin.version>
-        <graalvm-reachability-metadata.version>0.3.23</graalvm-reachability-metadata.version>
+        <native-maven-plugin.version>0.11.0</native-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     </properties>
 
@@ -157,13 +156,6 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-            <scope>test</scope>
-            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -281,62 +273,8 @@
                         <configuration>
                             <quickBuild>true</quickBuild>
                             <buildArgs>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.api.DisplayNameGenerator$IndicativeSentences
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor$ClassInfo
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor$LifecycleMethods
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.ClassTemplateInvocationTestDescriptor
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.ClassTemplateTestDescriptor
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.DynamicDescendantFilter$Mode
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.ExclusiveResourceCollector$1
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.descriptor.MethodBasedTestDescriptor$MethodInfo
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.jupiter.engine.discovery.ClassSelectorResolver$DummyClassTemplateInvocationContext
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.engine.support.store.NamespacedHierarchicalStore$EvaluatedValue
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.launcher.core.DiscoveryIssueNotifier
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.launcher.core.HierarchicalOutputDirectoryProvider
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.launcher.core.LauncherDiscoveryResult$EngineResultInfo
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.launcher.core.LauncherPhase
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.suite.engine.DiscoverySelectorResolver
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.suite.engine.SuiteTestDescriptor$DiscoveryIssueForwardingListener
-                                </buildArg>
-                                <buildArg>
-                                    --initialize-at-build-time=org.junit.platform.suite.engine.SuiteTestDescriptor$LifecycleMethods
-                                </buildArg>
+                                <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
                             </buildArgs>
-                            <metadataRepository>
-                                <enabled>true</enabled>
-                                <version>${graalvm-reachability-metadata.version}</version>
-                            </metadataRepository>
                         </configuration>
                         <executions>
                             <execution>

--- a/subprojects/doc/CONTRIBUTING.md
+++ b/subprojects/doc/CONTRIBUTING.md
@@ -161,9 +161,6 @@ The contents of `~/.m2/settings.xml` might be as follows.
 Then execute the following command.
 Suppose the release to be released is `1.8.0`, and the next version is `2.0.0-SNAPSHOT`.
 
-**Warning: `echo "test" | gpg --clearsign` cannot be executed in PowerShell 7 of `IntelliJ IDEA`. 
-You need to open PowerShell 7 in the Windows terminal to execute this command.**
-
 ```shell
 git clone git@github.com:linghengqian/hive-server2-jdbc-driver.git
 cd ./hive-server2-jdbc-driver/


### PR DESCRIPTION
- Bump GraalVM Native Build Tools to 0.11.0 .
- Also see https://github.com/graalvm/native-build-tools/pull/752 . I have absolutely no idea why GraalVM Native Build Tools 0.11.0 would try to find `tools.jar`.