### PR TITLE
Add Windows Server 2025 CI on GraalVM Native Image via Rancher Desktop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,5 +76,33 @@ jobs:
           native-image-pr-reports-update-existing: 'true'
       - name: NativeTest on GraalVM CE For JDK ${{ matrix.java }} on Ubuntu
         if: matrix.os == 'ubuntu-latest'
+        run: ./mvnw -T 1.5C -PnativeTestInCustom clean test
+  # todo wait for GraalVM CE For JDK 25 release
+  native-test-ci-on-oracle-graalvm:
+    name: NativeTest - GraalVM CE for JDK ${{ matrix.java }} on ${{ matrix.os }}
+    if: github.repository == 'linghengqian/hive-server2-jdbc-driver'
+    strategy:
+      matrix:
+        java: [ '25-ea' ]
+        os: [ 'ubuntu-latest', 'windows-2025' ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rancher Desktop without GUI on Windows Server
+        if: matrix.os == 'windows-2025'
         run: |
-          ./mvnw -T 1.5C -PnativeTestInCustom clean test
+          ./subprojects/doc/helpful_tools/uninstall-docker-engine-for-wcow.ps1
+          winget install --id jazzdelightsme.WingetPathUpdater --source winget
+          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+          rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
+          ./subprojects/doc/helpful_tools/wait-for-rancher-desktop-backend.ps1
+          "PATH=$env:PATH" >> $env:GITHUB_ENV
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cache: 'maven'
+          native-image-job-reports: 'true'
+      - name: NativeTest on Oracle GraalVM For JDK ${{ matrix.java }}
+        run: ./mvnw -T 1.5C -PnativeTestInCustom clean test

--- a/subprojects/doc/FAQ.md
+++ b/subprojects/doc/FAQ.md
@@ -118,9 +118,3 @@ Possible Maven 3 examples are as follows,
      </build>
 </project>
 ```
-
-## Why doesn't the project have NativeTest CI for the Runner for `windows-2025`?
-
-We have run the NativeTest test suite under the HotSpot VM of Windows Server 2025 CI. 
-However, due to the lack of local test environment of Windows Server 2025 for developers, 
-the NativeTest test suite has not yet been run under the GraalVM Native Image of Windows Server 2025 CI.


### PR DESCRIPTION
- Add Windows Server 2025 CI on GraalVM Native Image via Rancher Desktop.