### PR TITLE
Enable parallel testing with JUnit Framework

### DIFF
--- a/subprojects/tinycircus/README.md
+++ b/subprojects/tinycircus/README.md
@@ -36,7 +36,7 @@ Assuming `Docker Engine` are installed, a possible use case is as follows. Creat
 ```yaml
 services:
   some-postgres:
-    image: postgres:17.2-bookworm
+    image: postgres:17.5-bookworm
     environment:
       POSTGRES_PASSWORD: "example"
   hiveserver2-standalone:

--- a/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
+++ b/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/InformationSchemaTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.thin;
 
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 public class InformationSchemaTest {
 
     @AutoClose
@@ -43,7 +45,7 @@ public class InformationSchemaTest {
 
     @Container
     @AutoClose
-    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.5-bookworm")
             .withEnv("POSTGRES_PASSWORD", "example")
             .withNetwork(NETWORK)
             .withNetworkAliases("some-postgres");

--- a/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
+++ b/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/StandaloneMetastoreTest.java
@@ -21,6 +21,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.github.linghengqian.hive.server2.jdbc.driver.thin.util.ImageUtils;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 public class StandaloneMetastoreTest {
 
     @AutoClose

--- a/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
+++ b/thin/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/thin/ZookeeperServiceDiscoveryTest.java
@@ -24,6 +24,7 @@ import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -43,6 +44,7 @@ import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "resource", "deprecation"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 class ZookeeperServiceDiscoveryTest {
 
     private static final int RANDOM_PORT_FIRST = getRandomPort();

--- a/thin/src/test/resources/junit-platform.properties
+++ b/thin/src/test/resources/junit-platform.properties
@@ -1,0 +1,19 @@
+# Copyright 2025 Qiheng He
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=2

--- a/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
+++ b/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/InformationSchemaTest.java
@@ -18,6 +18,7 @@ package io.github.linghengqian.hive.server2.jdbc.driver.uber;
 
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 public class InformationSchemaTest {
 
     @AutoClose
@@ -43,7 +45,7 @@ public class InformationSchemaTest {
 
     @Container
     @AutoClose
-    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.2-bookworm")
+    private static final GenericContainer<?> POSTGRES = new GenericContainer<>("postgres:17.5-bookworm")
             .withEnv("POSTGRES_PASSWORD", "example")
             .withNetwork(NETWORK)
             .withNetworkAliases("some-postgres");

--- a/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
+++ b/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/StandaloneMetastoreTest.java
@@ -21,6 +21,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import io.github.linghengqian.hive.server2.jdbc.driver.uber.util.ImageUtils;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings({"SqlNoDataSourceInspection", "resource"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 public class StandaloneMetastoreTest {
 
     @AutoClose

--- a/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
+++ b/uber/src/test/java/io/github/linghengqian/hive/server2/jdbc/driver/uber/ZookeeperServiceDiscoveryTest.java
@@ -24,6 +24,7 @@ import org.apache.hive.org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.hive.org.apache.curator.retry.ExponentialBackoffRetry;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -43,6 +44,7 @@ import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection", "resource", "deprecation"})
 @Testcontainers
+@Isolated("This unit test starts two or more Linux containers, which will hit the performance limit of GitHub Actions Runner")
 class ZookeeperServiceDiscoveryTest {
 
     private static final int RANDOM_PORT_FIRST = getRandomPort();

--- a/uber/src/test/resources/junit-platform.properties
+++ b/uber/src/test/resources/junit-platform.properties
@@ -1,0 +1,19 @@
+# Copyright 2025 Qiheng He
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.classes.default = concurrent
+junit.jupiter.execution.parallel.config.strategy = fixed
+junit.jupiter.execution.parallel.config.fixed.parallelism = 2
+junit.jupiter.execution.parallel.config.fixed.max-pool-size=2


### PR DESCRIPTION
- Enable parallel testing with JUnit Framework.
- The description in https://java.testcontainers.org/test_framework_integration/junit_5/#limitations is quite interesting. But I think the unit tests I designed can avoid side effects in terms of isolation. In general, if a unit test starts more than one Linux Container, the related unit tests will be further isolated.

> This extension has only been tested with sequential test execution. Using it with parallel test execution is unsupported and may have unintended side effects.