### PR TITLE
Fix unstable CI on Windows Server 2025

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,12 +75,11 @@ jobs:
           native-image-job-reports: 'true'
           native-image-pr-reports: 'true'
           native-image-pr-reports-update-existing: 'true'
-      - name: NativeTest on GraalVM CE For JDK ${{ matrix.java }} on Ubuntu
-        if: matrix.os == 'ubuntu-latest'
+      - name: NativeTest on GraalVM CE For JDK ${{ matrix.java }}
         run: ./mvnw -PnativeTestInCustom -T 1.5C clean test
   # todo wait for GraalVM CE For JDK 25 release
   native-test-ci-on-oracle-graalvm:
-    name: NativeTest - GraalVM CE for JDK ${{ matrix.java }} on ${{ matrix.os }}
+    name: NativeTest - Oracle GraalVM for JDK ${{ matrix.java }} on ${{ matrix.os }}
     if: github.repository == 'linghengqian/hive-server2-jdbc-driver'
     strategy:
       matrix:
@@ -105,5 +104,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
+      # TODO The `-T 1.5C` flag cannot be used because the `native-maven-plugin` is poorly designed,
+      #   with many MOJOs bundled with the Maven lifecycle by default.
+      #   See https://github.com/graalvm/native-build-tools/issues/410 .
       - name: NativeTest on Oracle GraalVM For JDK ${{ matrix.java }}
-        run: ./mvnw -PnativeTestInCustom -T 1.5C clean test
+        run: ./mvnw -PnativeTestInCustom clean test

--- a/reachability-metadata/src/main/resources/META-INF/native-image/io.github.linghengqian/hive-server2-jdbc-driver-reachability-metadata/reflect-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/io.github.linghengqian/hive-server2-jdbc-driver-reachability-metadata/reflect-config.json
@@ -71,7 +71,16 @@
   "allDeclaredConstructors": true
 },
 {
+  "condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
+  "name":"com.ctc.wstx.stax.WstxOutputFactory"
+},
+{
   "condition":{"typeReachable":"org.apache.zookeeper.client.ZooKeeperSaslClient"},
+  "name":"sun.security.provider.ConfigFile",
+  "methods":[{"name":"<init>","parameterTypes":[] }]
+},
+{
+  "condition":{"typeReachable":"org.apache.hive.org.apache.zookeeper.client.ZooKeeperSaslClient"},
   "name":"sun.security.provider.ConfigFile",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 }

--- a/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1-standalone/reflect-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1-standalone/reflect-config.json
@@ -8,9 +8,14 @@
   "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"}
 },
 {
+  "condition":{"typeReachable":"org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
+  "name":"org.apache.hive.org.apache.commons.logging.impl.Log4JLogger"
+},
+{
   "name": "org.apache.hive.org.apache.commons.logging.impl.Jdk14Logger",
   "condition": {"typeReachable": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl"},
-  "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}]
+  "methods": [{"name": "<init>", "parameterTypes": ["java.lang.String"]}],
+  "allPublicMethods": true
 },
 {
   "name": "org.apache.hive.org.apache.commons.logging.impl.LogFactoryImpl",

--- a/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1-standalone/resource-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/org.apache.hive/hive-jdbc/4.0.1-standalone/resource-config.json
@@ -1,0 +1,11 @@
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.apache.hive.org.apache.commons.logging.LogFactory"},
+    "pattern":"\\Qcommons-logging.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.apache.hive.org.apache.commons.logging.LogFactory"},
+    "pattern":"\\QMETA-INF/services/org.apache.commons.logging.LogFactory\\E"
+  }]},
+  "bundles":[]
+}

--- a/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/resource-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/resource-config.json
@@ -15,6 +15,9 @@
   }, {
     "condition":{"typeReachable":"org.junit.platform.launcher.core.LauncherConfigurationParameters"},
     "pattern":"\\Qjunit-platform.properties\\E"
+  }, {
+    "condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
+    "pattern":"\\QMETA-INF/services/javax.xml.stream.XMLOutputFactory\\E"
   }]},
   "bundles":[]
 }

--- a/subprojects/doc/CHANGELOG.md
+++ b/subprojects/doc/CHANGELOG.md
@@ -15,6 +15,7 @@ io.github.linghengqian:hive-server2-jdbc-driver-uber:2.0.0-SNAPSHOT
 
 1. Only configure `native-image.properties` related to `io.grpc:grpc-netty-shaded` in Thin JAR.
    This is because the Uber JAR of HiveServer2 JDBC Driver does not use `io.grpc:grpc-netty-shaded`.
+2. Add more GraalVM Reachability Metadata for `org.apache.hive:hive-jdbc:4.0.1:standalone`.
 
 Build from `apache/hive:rel/release-4.0.1`.
 

--- a/subprojects/doc/CONTRIBUTING.md
+++ b/subprojects/doc/CONTRIBUTING.md
@@ -45,12 +45,12 @@ cd ./hive-server2-jdbc-driver/
 ```shell
 git clone git@github.com:linghengqian/hive-server2-jdbc-driver.git
 cd ./hive-server2-jdbc-driver/
-./mvnw -PnativeTestInCustom -T 1.5C clean test
+./mvnw -PnativeTestInCustom clean test
 ```
 
 ### Special handling for Windows 11
 
-If you execute `./mvnw -PnativeTestInCustom -T 1.5C clean test` under Windows 11, 
+If you execute `./mvnw -PnativeTestInCustom clean test` under Windows 11, 
 a window may pop up asking you to set up `控制面板\系统和安全\Windows Defender 防火墙\允许的应用` for `native-tests.exe` 
 like `D:\twinklingliftworks\git\public\hive-server2-jdbc-driver\thin\target\native-tests.exe.exe`. 
 At this time, you need to set up `专用` and `公用` for this.


### PR DESCRIPTION
- Fix unstable CI on Windows Server 2025.
- The `-T 1.5C` flag cannot be used because the `native-maven-plugin` is poorly designed, with many MOJOs bundled with the Maven lifecycle by default. See https://github.com/graalvm/native-build-tools/issues/410 .