### PR TITLE
Release v1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For the Docker Image of `apache/hive:4.0.0`,
 you can use `1.4.0` of `io.github.linghengqian:hive-server2-jdbc-driver-thin` or `io.github.linghengqian:hive-server2-jdbc-driver-uber`.
 
 For the Docker Image of `apache/hive:4.0.1`, 
-you can use `1.7.0` of `io.github.linghengqian:hive-server2-jdbc-driver-thin` or `io.github.linghengqian:hive-server2-jdbc-driver-uber`.
+you can use `1.8.1` of `io.github.linghengqian:hive-server2-jdbc-driver-thin` or `io.github.linghengqian:hive-server2-jdbc-driver-uber`.
 
 ### For HiveServer2 `4.1.x`
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.linghengqian</groupId>
     <artifactId>hive-parent</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.8.1</version>
 
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/reachability-metadata/pom.xml
+++ b/reachability-metadata/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.github.linghengqian</groupId>
         <artifactId>hive-parent</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.8.1</version>
     </parent>
     <artifactId>hive-server2-jdbc-driver-reachability-metadata</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/subprojects/doc/QuickStart.md
+++ b/subprojects/doc/QuickStart.md
@@ -13,7 +13,7 @@ Use third-party builds of this project in any Maven project.
     <dependency>
         <groupId>io.github.linghengqian</groupId>
         <artifactId>hive-server2-jdbc-driver-thin</artifactId>
-        <version>1.7.0</version>
+        <version>1.8.1</version>
     </dependency>
     <dependency>
         <groupId>com.zaxxer</groupId>

--- a/thin/pom.xml
+++ b/thin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.github.linghengqian</groupId>
         <artifactId>hive-parent</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.8.1</version>
     </parent>
     <artifactId>hive-server2-jdbc-driver-thin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/uber/pom.xml
+++ b/uber/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.github.linghengqian</groupId>
         <artifactId>hive-parent</artifactId>
-        <version>1.8.1-SNAPSHOT</version>
+        <version>1.8.1</version>
     </parent>
     <artifactId>hive-server2-jdbc-driver-uber</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
- Release v1.8.1
- Fixes https://github.com/linghengqian/hive-server2-jdbc-driver/issues/48 .