### PR TITLE
Fix warning about `java.logging` module in nativeTest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,12 +73,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
           native-image-job-reports: 'true'
-      - name: NativeTest on GraalVM CE For JDK 22.0.2
+      # TODO The `-T 1.5C` flag cannot be used because the `native-maven-plugin` is poorly designed,
+      #   with many MOJOs bundled with the Maven lifecycle by default.
+      #   See https://github.com/graalvm/native-build-tools/issues/410 .
+      - name: NativeTest on GraalVM CE For JDK 22.0.2 on ${{ matrix.os }}
         if: matrix.java == '22.0.2'
-        run: ./mvnw -PnativeTestInCustom -T 1.5C clean test
-      - name: NativeTest on GraalVM CE For JDK 24.0.2
+        run: ./mvnw -PnativeTestInCustom clean test
+      - name: NativeTest on GraalVM CE For JDK 24.0.2 on ${{ matrix.os }}
         if: matrix.java == '24.0.2'
-        run: ./mvnw -PnativeTestInJava23+ -T 1.5C clean test
+        run: ./mvnw -PnativeTestInJava23+ clean test
   # todo wait for GraalVM CE For JDK 25 release
   native-test-ci-on-oracle-graalvm:
     name: NativeTest - Oracle GraalVM for JDK ${{ matrix.java }} on ${{ matrix.os }}
@@ -109,5 +112,5 @@ jobs:
       # TODO The `-T 1.5C` flag cannot be used because the `native-maven-plugin` is poorly designed,
       #   with many MOJOs bundled with the Maven lifecycle by default.
       #   See https://github.com/graalvm/native-build-tools/issues/410 .
-      - name: NativeTest on Oracle GraalVM For JDK ${{ matrix.java }}
+      - name: NativeTest on Oracle GraalVM For JDK ${{ matrix.java }} on ${{ matrix.os }}
         run: ./mvnw -PnativeTestInJava23+ clean test

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
@@ -211,7 +210,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <version>${maven-source-plugin.version}</version>
                         <executions>
@@ -224,7 +222,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>${maven-javadoc-plugin.version}</version>
                         <executions>
@@ -237,7 +234,6 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>${maven-gpg-plugin.version}</version>
                         <executions>

--- a/reachability-metadata/src/main/resources/META-INF/native-image/io.github.linghengqian/hive-server2-jdbc-driver-reachability-metadata/reflect-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/io.github.linghengqian/hive-server2-jdbc-driver-reachability-metadata/reflect-config.json
@@ -67,10 +67,6 @@
   "allDeclaredConstructors": true
 },
 {
-  "condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
-  "name":"com.ctc.wstx.stax.WstxOutputFactory"
-},
-{
   "condition":{"typeReachable":"org.apache.zookeeper.client.ZooKeeperSaslClient"},
   "name":"sun.security.provider.ConfigFile",
   "methods":[{"name":"<init>","parameterTypes":[] }]

--- a/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/reachability-metadata.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/reachability-metadata.json
@@ -1,0 +1,11 @@
+{
+  "resources": [
+    {
+      "condition": {
+        "typeReached": "org.junit.platform.commons.logging.LoggerFactory"
+      },
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_*.properties"
+    }
+  ]
+}

--- a/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/resource-config.json
+++ b/reachability-metadata/src/main/resources/META-INF/native-image/org.junit.jupiter/junit-jupiter/5.13.4/resource-config.json
@@ -15,9 +15,6 @@
   }, {
     "condition":{"typeReachable":"org.junit.platform.launcher.core.LauncherConfigurationParameters"},
     "pattern":"\\Qjunit-platform.properties\\E"
-  }, {
-    "condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
-    "pattern":"\\QMETA-INF/services/javax.xml.stream.XMLOutputFactory\\E"
   }]},
   "bundles":[]
 }

--- a/subprojects/doc/FAQ.md
+++ b/subprojects/doc/FAQ.md
@@ -43,77 +43,122 @@ Since only the `org.apache.hadoop.mapred.JobConf` class is needed, excluding all
 </dependency>
 ```
 
-## Why do I get the exception `java.nio.charset.UnsupportedCharsetException: Cp1252` after compiling dependencies into GraalVM Native Image?
+## Why do I get a warning about `META-INF/services/javax.xml.stream.XMLOutputFactory`?
 
-This does not normally happen on Ubuntu systems.
-
-When compiling a GraalVM Native Image containing `io.github.linghengqian:hive-server2-jdbc-driver-thin` with Windows 11 Home 24H2, 
-you may get an exception of `java.nio.charset.UnsupportedCharsetException: Cp1252`.
+If you use `io.github.linghengqian:hive-server2-jdbc-driver-uber` under GraalVM Native Image, you may see this Warning.
 
 ```shell
-Jul 26, 2025 3:56:43 PM com.sun.jna.Native <clinit>
-WARNING: Failed to get charset for native.encoding value : 'Cp1252'
-java.nio.charset.UnsupportedCharsetException: Cp1252
-	at java.base@22.0.2/java.nio.charset.Charset.forName(Charset.java:559)
-	at com.sun.jna.Native.<clinit>(Native.java:133)
-	at com.github.dockerjava.transport.NamedPipeSocket$Kernel32.<clinit>(NamedPipeSocket.java:82)
-	at com.github.dockerjava.transport.NamedPipeSocket.connect(NamedPipeSocket.java:64)
-	at com.github.dockerjava.transport.NamedPipeSocket.connect(NamedPipeSocket.java:43)
-	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$test$3(DockerClientProviderStrategy.java:214)
-	at org.testcontainers.shaded.org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
-	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
-	at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
-	at java.base@22.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:317)
-	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
-	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
-	at java.base@22.0.2/java.lang.Thread.runWith(Thread.java:1583)
-	at java.base@22.0.2/java.lang.Thread.run(Thread.java:1570)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:853)
-	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:829)
+WARNING: Type implements CloseableResource but not AutoCloseable: org.testcontainers.junit.jupiter.TestcontainersExtension$StoreAdapter
+com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: Cannot access resource at path 'META-INF/services/javax.xml.stream.XMLOutputFactory'. To allow this operation, add the following to the 'resources' section of 'reachability-metadata.json' and rebuild the native image:
+
+  {
+    "glob": "META-INF/services/javax.xml.stream.XMLOutputFactory"
+  }
+
+The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources
+  java.base@25/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
+  java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:275)
+  java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:239)
+  java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:192)
+  java.xml@25/javax.xml.stream.XMLOutputFactory.newInstance(XMLOutputFactory.java:143)
+  org.junit.platform.reporting.legacy.xml.XmlReportWriter$XmlReport.<init>(XmlReportWriter.java:130)
+  org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:118)
+  org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:101)
 ```
 
-But if you encounter this Error Log, you can pass the `buildArg` of `-H:+AddAllCharsets` to GraalVM Native Build Tools. 
-Possible Maven 3 examples are as follows,
+This is intentional, 
+because `io.github.linghengqian:hive-server2-jdbc-driver-uber` does not have a `com.ctc.wstx.stax.WstxOutputFactory` class, 
+but only a `org.apache.hive.com.ctc.wstx.stax.WstxOutputFactory` class.
 
-```xml
-<project>
-     <dependencies>
-         <dependency>
-             <groupId>io.github.linghengqian</groupId>
-             <artifactId>hive-server2-jdbc-driver-thin</artifactId>
-             <version>1.8.1</version>
-         </dependency>
-     </dependencies>
-     <build>
-         <plugins>
-             <plugin>
-                 <groupId>org.graalvm.buildtools</groupId>
-                 <artifactId>native-maven-plugin</artifactId>
-                 <version>0.11.0</version>
-                 <extensions>true</extensions>
-                 <configuration>
-                    <buildArgs>
-                       <buildArg>-H:+AddAllCharsets</buildArg>
-                    </buildArgs>
-                 </configuration>
-                 <executions>
-                     <execution>
-                         <id>build-native</id>
-                         <goals>
-                             <goal>compile-no-fork</goal>
-                         </goals>
-                         <phase>package</phase>
-                     </execution>
-                     <execution>
-                         <id>test-native</id>
-                         <goals>
-                             <goal>test</goal>
-                         </goals>
-                         <phase>test</phase>
-                     </execution>
-                 </executions>
-             </plugin>
-         </plugins>
-     </build>
-</project>
+If you really want this warning log to disappear, 
+you can introduce a dependency on `com.fasterxml.woodstox:woodstox-core:5.4.0` in a build tool such as Maven or Gradle.
+`com.fasterxml.woodstox:woodstox-core:5.4.0` is also a dependency of `org.apache.hadoop:hadoop-common:3.3.6`.
+
+Then create the following JSON entry in any `resource-config.json` on the classpath.
+
+```json
+{
+  "resources":{
+  "includes":[{
+    "condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
+    "pattern":"\\QMETA-INF/services/javax.xml.stream.XMLOutputFactory\\E"
+  }]},
+  "bundles":[]
+}
+```
+
+Then create the following JSON entry in any `reflect-config.json` on the classpath.
+
+```json
+[
+{
+"condition":{"typeReachable":"org.junit.platform.reporting.legacy.xml.XmlReportWriter"},
+"name":"com.ctc.wstx.stax.WstxOutputFactory"
+}
+]
+```
+
+If there are no related dependency `com.fasterxml.woodstox:woodstox-core:5.4.0`, it will result in,
+
+```shell
+```shell
+Aug 05, 2025 3:09:36 PM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$21
+WARNING: TestExecutionListener [org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener] threw exception for method: executionFinished(TestIdentifier [uniqueId = [engine:junit-jupiter], parentId = null, displayName = 'JUnit Jupiter', legacyReportingName = 'JUnit Jupiter', source = null, tags = [], type = CONTAINER], TestExecutionResult [status = SUCCESSFUL, throwable = null])
+javax.xml.stream.FactoryConfigurationError: Provider for class javax.xml.stream.XMLOutputFactory cannot be created
+	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:291)
+	at java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:239)
+	at java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:192)
+	at java.xml@25/javax.xml.stream.XMLOutputFactory.newInstance(XMLOutputFactory.java:143)
+	at org.junit.platform.reporting.legacy.xml.XmlReportWriter$XmlReport.<init>(XmlReportWriter.java:130)
+	at org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:118)
+	at org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:101)
+	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.writeXmlReportSafely(LegacyXmlReportGeneratingListener.java:117)
+	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.writeXmlReportInCaseOfRoot(LegacyXmlReportGeneratingListener.java:110)
+	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.executionFinished(LegacyXmlReportGeneratingListener.java:104)
+	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$executionFinished$10(CompositeTestExecutionListener.java:74)
+	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$notifyEach$21(CompositeTestExecutionListener.java:110)
+	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:263)
+	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
+	at org.junit.platform.launcher.core.CompositeTestExecutionListener.notifyEach(CompositeTestExecutionListener.java:108)
+	at org.junit.platform.launcher.core.CompositeTestExecutionListener.executionFinished(CompositeTestExecutionListener.java:73)
+	at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:57)
+	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$executionFinished$6(CompositeEngineExecutionListener.java:60)
+	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$notifyEach$13(CompositeEngineExecutionListener.java:82)
+	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:263)
+	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
+	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.notifyEach(CompositeEngineExecutionListener.java:80)
+	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.executionFinished(CompositeEngineExecutionListener.java:59)
+	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:47)
+	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.executionFinished(StackTracePruningEngineExecutionListener.java:46)
+	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:47)
+	at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.reportEngineOutcome(OutcomeDelayingEngineExecutionListener.java:69)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:233)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:100)
+	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
+	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$2(InterceptingLauncher.java:47)
+	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
+	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:46)
+	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
+	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:73)
+	at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:132)
+	at java.base@25/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
+Caused by: java.lang.RuntimeException: Provider for class javax.xml.stream.XMLOutputFactory cannot be created
+	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:288)
+	... 43 more
+Caused by: java.util.ServiceConfigurationError: javax.xml.stream.XMLOutputFactory: Provider com.ctc.wstx.stax.WstxOutputFactory not found
+	at java.base@25/java.util.ServiceLoader.fail(ServiceLoader.java:559)
+	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1090)
+	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1099)
+	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
+	at java.base@25/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
+	at java.base@25/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
+	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:275)
+	... 43 more
 ```

--- a/thin/src/test/resources/META-INF/native-image/test-metadata/reachability-metadata.json
+++ b/thin/src/test/resources/META-INF/native-image/test-metadata/reachability-metadata.json
@@ -80,14 +80,5 @@
         }
       }
     }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org.junit.platform.commons.logging.LoggerFactory"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
-    }
   ]
 }

--- a/uber/src/test/resources/META-INF/native-image/test-metadata/reachability-metadata.json
+++ b/uber/src/test/resources/META-INF/native-image/test-metadata/reachability-metadata.json
@@ -80,14 +80,5 @@
         }
       }
     }
-  ],
-  "resources": [
-    {
-      "condition": {
-        "typeReached": "org.junit.platform.commons.logging.LoggerFactory"
-      },
-      "module": "java.logging",
-      "glob": "sun/util/logging/resources/logging_en.properties"
-    }
   ]
 }


### PR DESCRIPTION
- Fix warning about `java.logging` module in nativeTest.
```shell
com.oracle.svm.core.jdk.resources.MissingResourceRegistrationError: Cannot access resource from module 'java.logging' at path 'sun/util/logging/resources/logging_en_US.properties'. To allow this operation, add the following to the 'resources' section of 'reachability-metadata.json' and rebuild the native image:

  {
    "module": "java.logging",
    "glob": "sun/util/logging/resources/logging_en_US.properties"
  }

The 'reachability-metadata.json' file should be located in 'META-INF/native-image/<group-id>/<artifact-id>/' of your project. For further help, see https://www.graalvm.org/latest/reference-manual/native-image/metadata/#resources
  java.base@25/java.util.ResourceBundle$1.getBundle(ResourceBundle.java:401)
  java.logging@25/java.util.logging.Level.computeLocalizedLevelName(Level.java:293)
  java.logging@25/java.util.logging.Level.getLocalizedLevelName(Level.java:353)
  java.logging@25/java.util.logging.SimpleFormatter.format(SimpleFormatter.java:185)
  java.logging@25/java.util.logging.StreamHandler.publish(StreamHandler.java:207)
  java.logging@25/java.util.logging.ConsoleHandler.publish(ConsoleHandler.java:101)
  java.logging@25/java.util.logging.Logger.log(Logger.java:962)
  org.junit.platform.commons.logging.LoggerFactory$DelegatingLogger.log(LoggerFactory.java:148)
```
- In the Uber JAR, there is only the `org.apache.hive.com.ctc.wstx.stax.WstxOutputFactory` class, but no `com.ctc.wstx.stax.WstxOutputFactory` class. See https://github.com/linghengqian/hive-server2-jdbc-driver/actions/runs/16753079066/job/47428223406 .
```
```shell
Aug 05, 2025 3:09:36 PM org.junit.platform.launcher.core.CompositeTestExecutionListener lambda$notifyEach$21
WARNING: TestExecutionListener [org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener] threw exception for method: executionFinished(TestIdentifier [uniqueId = [engine:junit-jupiter], parentId = null, displayName = 'JUnit Jupiter', legacyReportingName = 'JUnit Jupiter', source = null, tags = [], type = CONTAINER], TestExecutionResult [status = SUCCESSFUL, throwable = null])
javax.xml.stream.FactoryConfigurationError: Provider for class javax.xml.stream.XMLOutputFactory cannot be created
	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:291)
	at java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:239)
	at java.xml@25/javax.xml.stream.FactoryFinder.find(FactoryFinder.java:192)
	at java.xml@25/javax.xml.stream.XMLOutputFactory.newInstance(XMLOutputFactory.java:143)
	at org.junit.platform.reporting.legacy.xml.XmlReportWriter$XmlReport.<init>(XmlReportWriter.java:130)
	at org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:118)
	at org.junit.platform.reporting.legacy.xml.XmlReportWriter.writeXmlReport(XmlReportWriter.java:101)
	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.writeXmlReportSafely(LegacyXmlReportGeneratingListener.java:117)
	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.writeXmlReportInCaseOfRoot(LegacyXmlReportGeneratingListener.java:110)
	at org.junit.platform.reporting.legacy.xml.LegacyXmlReportGeneratingListener.executionFinished(LegacyXmlReportGeneratingListener.java:104)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$executionFinished$10(CompositeTestExecutionListener.java:74)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.lambda$notifyEach$21(CompositeTestExecutionListener.java:110)
	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:263)
	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.notifyEach(CompositeTestExecutionListener.java:108)
	at org.junit.platform.launcher.core.CompositeTestExecutionListener.executionFinished(CompositeTestExecutionListener.java:73)
	at org.junit.platform.launcher.core.ExecutionListenerAdapter.executionFinished(ExecutionListenerAdapter.java:57)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$executionFinished$6(CompositeEngineExecutionListener.java:60)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.lambda$notifyEach$13(CompositeEngineExecutionListener.java:82)
	at org.junit.platform.commons.util.CollectionUtils.forEachInReverseOrder(CollectionUtils.java:263)
	at org.junit.platform.launcher.core.IterationOrder$2.forEach(IterationOrder.java:30)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.notifyEach(CompositeEngineExecutionListener.java:80)
	at org.junit.platform.launcher.core.CompositeEngineExecutionListener.executionFinished(CompositeEngineExecutionListener.java:59)
	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:47)
	at org.junit.platform.launcher.core.StackTracePruningEngineExecutionListener.executionFinished(StackTracePruningEngineExecutionListener.java:46)
	at org.junit.platform.launcher.core.DelegatingEngineExecutionListener.executionFinished(DelegatingEngineExecutionListener.java:47)
	at org.junit.platform.launcher.core.OutcomeDelayingEngineExecutionListener.reportEngineOutcome(OutcomeDelayingEngineExecutionListener.java:69)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.executeEngine(EngineExecutionOrchestrator.java:233)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.failOrExecuteEngine(EngineExecutionOrchestrator.java:204)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:172)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:101)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:64)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:150)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:63)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:109)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:100)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
	at org.junit.platform.launcher.core.InterceptingLauncher.lambda$execute$2(InterceptingLauncher.java:47)
	at org.junit.platform.launcher.core.ClasspathAlignmentCheckingLauncherInterceptor.intercept(ClasspathAlignmentCheckingLauncherInterceptor.java:25)
	at org.junit.platform.launcher.core.InterceptingLauncher.execute(InterceptingLauncher.java:46)
	at org.junit.platform.launcher.core.DelegatingLauncher.execute(DelegatingLauncher.java:52)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:73)
	at org.graalvm.junit.platform.NativeImageJUnitLauncher.main(NativeImageJUnitLauncher.java:132)
	at java.base@25/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
Caused by: java.lang.RuntimeException: Provider for class javax.xml.stream.XMLOutputFactory cannot be created
	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:288)
	... 43 more
Caused by: java.util.ServiceConfigurationError: javax.xml.stream.XMLOutputFactory: Provider com.ctc.wstx.stax.WstxOutputFactory not found
	at java.base@25/java.util.ServiceLoader.fail(ServiceLoader.java:559)
	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.nextProviderClass(ServiceLoader.java:1090)
	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1099)
	at java.base@25/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
	at java.base@25/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
	at java.base@25/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1246)
	at java.xml@25/javax.xml.stream.FactoryFinder.findServiceProvider(FactoryFinder.java:275)
	... 43 more
```