### PR TITLE
Remove the redundant `--skip-dependencies` parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           ./subprojects/doc/helpful_tools/uninstall-docker-engine-for-wcow.ps1
           winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+          winget install --id SUSE.RancherDesktop --source winget
           rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./subprojects/doc/helpful_tools/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV
@@ -98,7 +98,7 @@ jobs:
         run: |
           ./subprojects/doc/helpful_tools/uninstall-docker-engine-for-wcow.ps1
           winget install --id jazzdelightsme.WingetPathUpdater --source winget
-          winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
+          winget install --id SUSE.RancherDesktop --source winget
           rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
           ./subprojects/doc/helpful_tools/wait-for-rancher-desktop-backend.ps1
           "PATH=$env:PATH" >> $env:GITHUB_ENV


### PR DESCRIPTION
- Remove the redundant `--skip-dependencies` parameter.
- Due to the release of WSL 2.5.10, the `--skip-dependencies` parameter is no longer required to install Rancher Desktop. WSL can already be installed and updated via winget. See https://github.com/microsoft/WSL/issues/13190 and https://github.com/microsoft/winget-pkgs/issues/281351 .